### PR TITLE
Don't link to raw resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ A step by step guide on how to use hammer.js:
 
 * Import jquery and import hammer.js in your project:
     
-```<script src="https://raw.github.com/EightMedia/hammer.js/master/hammer.js"></script>```
+```<script src="http://eightmedia.github.com/hammer.js/hammer.js"></script>```
 
 * Hammertime! Bind hammer to a container element:
 


### PR DESCRIPTION
If any huge site uses the resource this way, it can _ahem_ **hammer** our servers.  GitHub Pages was designed for heavy static page serving, please ask people to link static resources from there.

Also, this project is awesome.
