### PR TITLE
Fix for event normalization

### DIFF
--- a/hammer.js
+++ b/hammer.js
@@ -172,8 +172,8 @@ function Hammer(element, options, undefined)
                 body = doc.body;
 
             return [{
-                x: event.pageX || event.clientX + ( doc && doc.scrollLeft || body && body.scrollLeft || 0 ) - ( doc && doc.clientLeft || body && doc.clientLeft || 0 ),
-                y: event.pageY || event.clientY + ( doc && doc.scrollTop || body && body.scrollTop || 0 ) - ( doc && doc.clientTop || body && doc.clientTop || 0 )
+                x: event.pageX || event.clientX + ( doc && doc.scrollLeft || body && body.scrollLeft || 0 ) - ( doc && doc.clientLeft || body && body.clientLeft || 0 ),
+                y: event.pageY || event.clientY + ( doc && doc.scrollTop || body && body.scrollTop || 0 ) - ( doc && doc.clientTop || body && body.clientTop || 0 )
             }];
         }
         // multitouch, return array with positions


### PR DESCRIPTION
Just a minor typo fix: it was checking for body then applying properties
from doc, should have ben checking for body then applying properties
from body.  This affects I believe IEs, maybe only old ones.
