### PR TITLE
Finer direction for drag events

### DIFF
--- a/hammer.js
+++ b/hammer.js
@@ -389,6 +389,11 @@ function Hammer(element, options, undefined)
                     return;
                 }
 
+                var interim_angle = getAngle(_pos.interim || _pos.start[0], _pos.move[0]),
+                    interim_direction = self.getDirectionFromAngle(interim_angle);
+                _pos.interim = _pos.move[0];
+
+
                 _gesture = 'drag';
 
                 var position = { x: _pos.move[0].x - _offset.left,
@@ -401,7 +406,9 @@ function Hammer(element, options, undefined)
                     distance        : _distance,
                     distanceX       : _distance_x,
                     distanceY       : _distance_y,
-                    angle           : _angle
+                    angle           : _angle,
+                    interim_angle: interim_angle,
+                    interim_direction: interim_direction
                 };
 
                 // on the first time trigger the start event


### PR DESCRIPTION
I have added two new properties for drag events: interim_direction and interim_angle that reflect the change since the last time the event fired -- as opposed to the overall direction and angle.

This handles a problem discussed in #39 and allows for finer inspection of how the drag is being carried out.

Cheers!
