### PR TITLE
Touchend x, y position

### DIFF
--- a/hammer.js
+++ b/hammer.js
@@ -1,6 +1,6 @@
 /*
  * Hammer.JS
- * version 0.6.1
+ * version 0.6.2
  * author: Eight Media
  * https://github.com/EightMedia/hammer.js
  * Licensed under the MIT license.
@@ -628,10 +628,13 @@ function Hammer(element, options, undefined)
 
                 _prev_gesture = _gesture;
 
-                // trigger release event
+                // trigger release event. 
+                // "release" by default doesn't return the co-ords where your 
+                // finger was released. "position" will return "the last touched co-ords"
                 triggerEvent("release", {
                     originalEvent   : event,
-                    gesture         : _gesture
+                    gesture         : _gesture,
+                    position        : _pos.move || _pos.start
                 });
 
                 // reset vars


### PR DESCRIPTION
The "touchend", or "release", event by default does not return the x,y position the finger was released at when using a touch device. (which makes sense as there is no longer a finger on the screen).

On the desktop, using a mouse returns the x,y pos where the mouse button was released. To improve consistency between the desktop and mobile, I've made the change to return the last touched x,y position when a finger is released from the screen.

The exclusion of returning the released x,y position is confusing for novice users and often thought of as a bug.
