### PR TITLE
Drag to Transform

### DIFF
--- a/hammer.js
+++ b/hammer.js
@@ -565,6 +565,7 @@ function Hammer(element, options, undefined)
                     });
                 }
                 _setup();
+                _mousedown = true;
 
                 if(options.prevent_default) {
                     cancelEvent(event);
@@ -588,7 +589,11 @@ function Hammer(element, options, undefined)
                 _event_move = event;
                 _pos.move = getXYfromEvent(event);
 
-                if(!gestures.transform(event)) {
+                if (_has_touch) {
+                    _mousedown = true;
+                }
+
+                if(!gestures.transform(event) && _mousedown) {
                     gestures.drag(event);
                 }
                 break;
@@ -667,8 +672,6 @@ function Hammer(element, options, undefined)
                 top: box.top + scrollTop - clientTop,
                 left: box.left + scrollLeft - clientLeft
             };
-
-            _mousedown = true;
 
             // hold gesture
             gestures.hold(event);


### PR DESCRIPTION
I have to implement a iPad fidelity zoom with hammer.js.  Upon doing that i realized that hammer.js will not allow a user to go in between drag -> transform and transform -> drag. 

I have made it so that it is now possible.  I bumped the version to 6.3 (if accepted of course).

How it was done.

There are 3 bigger problems.
1)  Do not allow a "tap" event to be fired off when a user performs a transform -> drag -> release.
2)  Fire a dragend event when the user starts a drag -> transform 
3)  Fire a transformend when going transform -> drag (taken care of already by the hammer.js system).
