### PR TITLE
Minor change to enable non-touch-enabled desktop browsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,10 @@ On a desktop browser the mouse can be used to simulate touch events with one fin
 On Android 2 (and 3?) doesn't support multi-touch events, so there's no transform callback on these Android versions.
 Firefox 1.1 (Nokia N900) and Windows Phone 7.5 doesnt support touch events, and mouse events are badly supported.
 
-Not all gestures are supported on every device. This matrix shows the support we have tested. This is ofcourse far from extensive.
+This latest fork includes a feature that allows desktop browsers to react to touch events
+via TUIO. There are a couple of ways to get TUIO messages. One is using a plugin (see [MagicTouch](https://github.com/borismus/MagicTouch)), and another relies on node.js (see [tuiohost](https://github.com/acc3ptC/tuiohost)).
+
+Not all gestures are supported on every device. This matrix shows the support we have tested. This is of course far from extensive.
 If you've tested hammer.js on a different device, please let us know.
 
 

--- a/hammer.js
+++ b/hammer.js
@@ -36,7 +36,11 @@ function Hammer(element, options, undefined)
         tap_double_distance: 20,
 
         hold               : true,
-        hold_timeout       : 500
+        hold_timeout       : 500,
+
+        // for desktop browsers using TUIO
+        use_tuio           : false
+
     };
     options = mergeObject(defaults, options);
 
@@ -101,7 +105,7 @@ function Hammer(element, options, undefined)
     var _event_move;
     var _event_end;
 
-    var _has_touch = ('ontouchstart' in window);
+    var _has_touch = ('ontouchstart' in window || options['use_tuio']);
 
 
     /**
@@ -630,10 +634,7 @@ function Hammer(element, options, undefined)
                         originalEvent   : event,
                         position        : _pos.center,
                         scale           : calculateScale(_pos.start, _pos.move),
-                        rotation        : calculateRotation(_pos.start, _pos.move),
-                        distance        : _distance,
-                        distanceX       : _distance_x,
-                        distanceY       : _distance_y
+                        rotation        : calculateRotation(_pos.start, _pos.move)
                     });
                 }
                 else {


### PR DESCRIPTION
I've made a minor enhancement to enable desktop browsers to assert touch capability via TUIO using an option called use_tuio (which of course defaults to false). While I was there I also fixed a problem with transformend not firing.
