### PR TITLE
Transform drag

### DIFF
--- a/hammer.js
+++ b/hammer.js
@@ -340,7 +340,7 @@ function Hammer(element, options, undefined)
         // fired on touchend
         swipe : function(event)
         {
-            if(!_pos.move || _gesture === "transform") {
+            if (!_pos.move || _gesture === "transform") {
                 return;
             }
 


### PR DESCRIPTION
So this is my second attempt.

I found 2 bugs.

From my last attempt till now the big problem was this "continual drag" issue that would happen if there was a mouse on the screen.  Luckily, it was squashed with a simple if (!_mousedown && count === 1) return;

Second, from the fix of the first one, the drag-transform worked fine but the transform->drag did not.  SOO, on the mouseend|touchend event i would check to see if there is still a finger on the screen from a transform ending event.  if there is, then it would reset and do another _setup.  That way a drag would only fire if the remaining finger moved the proper dragdistance amount.
