### PR TITLE
jquery.specialevent.hammer.js delegate support

### DIFF
--- a/jquery.specialevent.hammer.js
+++ b/jquery.specialevent.hammer.js
@@ -7,32 +7,133 @@
 (function ($) {
     var hammerEvents = ['hold','tap','doubletap','transformstart','transform','transformend','dragstart','drag','dragend','swipe','release'];
 
+    /*
+     * HammerSEFunctions
+     * maintains which function should be used to handle
+     * events.
+     * 
+     * _fn : is the original function used to handle events.
+     *  Faster than _delegateFn, but it does not support delegated
+     *  or bubbled events through jQuery.
+     *
+     * _delegateFn : a function that supports delegated/bubbled events
+     *  in jQuery, but it is slower than _fn as it doesn't use a cached
+     *  jQuery call ($target) to trigger from and must construct a new
+     *  jQuery object based on the event target each time the event triggers.
+     *
+     * addDelegate : adds the handler guid created by jQuery to _delegateGuids.
+     *
+     * removeDelegate : removes the handler guid (if found) in _delegateGuids.
+     *
+     * getFn : returns either _fn or _delegateFn based on there being any handler
+     *  guids saved in _delegateGuids. If there are no guids saved, then the faster
+     *  function (_fn) is used. Otherwise, _delegateFn must be used and will be
+     *  returned.
+     *
+     * destroy : destroys all dynamically generated properties in the object. This
+     *  may be overkill, but it will help to reduce the chances of any sneaky
+     *  memory leaks cropping up.
+     */
+
+    function HammerSEFunctions(/*event,$target*/){
+        var event = arguments[0],
+            $target = arguments[1];
+
+        this._delegateGuids = [];
+
+        this._fn = function(ev){
+            
+            $target.trigger($.Event(event,ev));
+        
+        };
+
+        this._delegateFn = function(ev){
+            var jqevt = $.Event(event,ev);
+            
+            $(jqevt.originalEvent.target).trigger(jqevt);
+        
+        };
+    }
+    HammerSEFunctions.prototype = {
+
+        addDelegate : function(guid){
+            
+            this._delegateGuids.push(guid);
+            return this;
+        
+        },
+
+        removeDelegate : function(guid){
+            var index = this._delegateGuids.indexOf(guid);
+            
+            if(index >= 0){
+                
+                this._delegateGuids.splice(index);
+            
+            }
+            
+            return this;
+        },
+
+        getFn : function(){
+            
+            return this._delegateGuids.length > 0 ? this._delegateFn : this._fn;
+        
+        },
+
+        destroy : function(){
+            
+            this._fn = null;
+            this._delegateFn = null;
+            this._delegateGuids = null;
+            
+            delete this._fn;
+            delete this._delegateFn;
+            delete this._delegateGuids;
+        
+        }
+
+    };
+
     $.each(hammerEvents, function(i, event) {
 
         $.event.special[event] = {
 
             setup: function(data, namespaces, eventHandle) {
                 var $target = $(this),
-                    hammer;
-
-                if (!$target.hammer) {
-                    $target.data('hammerjs', new Hammer(this, data));
-                }
-
-                hammer = $target.data('hammerjs');
-
-                hammer['on'+ event] = function (ev) {
-                    $target.trigger($.Event(event, ev));
-                };
-            },
-
-            teardown: function(namespaces) {
-                var $target = $(this),
                     hammer = $target.data('hammerjs');
-
-                if(hammer && hammer['on'+ event]) {
-                    delete hammer['on'+ event];
+                
+                if (!hammer) {
+                    hammer = new Hammer(this, data);
+                    hammer.__Fns = {};
+                    $target.data('hammerjs', hammer);
                 }
+
+                hammer.__Fns[event] = new HammerSEFunctions(event,$target);
+            },
+            add : function(handleObj) {
+                var hammer = $(this).data('hammerjs');
+
+                if (!!handleObj.selector) {
+                    hammer.__Fns[event].addDelegate(handleObj.guid);
+                }
+
+                hammer['on' + event] = hammer.__Fns[event].getFn();
+            },
+            remove : function(handleObj) {
+                var hammer = $(this).data('hammerjs');
+
+                if (!!handleObj.selector) {
+                    hammer.__Fns[event].removeDelegate(handleObj.guid);
+                }
+
+                hammer['on' + event] = hammer.__Fns[event].getFn();
+            },
+            teardown: function(namespaces) {
+                var hammer = $(this).data('hammerjs');
+
+                hammer.__Fns[event].destroy();
+                delete hammer.__Fns[event];
             }
         };
     });


### PR DESCRIPTION
(this request seeks to fix the issue https://github.com/EightMedia/hammer.js/issues/85)
The current implementation does not support using delegated bindings in jQuery, example:

```
$('ul#root').on('tap','li a button',function(ev){}); // won't fire
```

This update adds a different method of triggering evens. This method is inherently slower than the current implementation, so a manager has also been added to automatically use the faster, original method over the new, slower, delegate-compatible method.
