### PR TITLE
Fix a strange bug where hammer.js was confused between drag and transform

### DIFF
--- a/hammer.js
+++ b/hammer.js
@@ -455,7 +455,7 @@ function Hammer(element, options, undefined)
                         y: ((_pos.move[0].y + _pos.move[1].y) / 2) - _offset.top
                     };
 
-                    if(_first)
+                    if(_first || _pos.startCenter === undefined)
                         _pos.startCenter = _pos.center;
 
                     var _distance_x = _pos.center.x - _pos.startCenter.x;


### PR DESCRIPTION
With following settings:

```
drag_min_distance: 0,
scale_threshold: 0,
prevent_default: true
```

I had the following problem on the change from drag to transform (i.e. one starts to drag with one finger and later a second finger is recognized so the mode changes to transform):

`TypeError: 'undefined' is not an object (evaluating '_pos.startCenter.x')`

It seemed that `_first` was already set to `true` but `_pos.startCenter` was not defined yet. 

I'm not sure if this is the right way to fix this, but It did the trick for me.
