### PR TITLE
jQuery plugin for Hammer.js which allows to use event listeners directly on jQuery elements.

### DIFF
--- a/jquery.hammer.js
+++ b/jquery.hammer.js
@@ -1,26 +1,50 @@
+/*globals Hammer, jQuery */
+
 /*
- * Hammer.JS jQuery plugin
- * version 0.3
- * author: Eight Media
- * https://github.com/EightMedia/hammer.js
+ * Hammer.js jQuery plugin based on Ha
+ *
+ * @author Łukasz Lipiński (uzza17@gmail.com)
+ * @version 0.1
+ * @license Released under the MIT license
+ * @see https://github.com/lukaszlipinski/jquery.hammer
  */
-jQuery.fn.hammer = function(options)
-{
-    return this.each(function()
-    {
-        var hammer = new Hammer(this, options);
 
-        var $el = jQuery(this);
-        $el.data("hammer", hammer);
+(function($, Hammer) {
+	"use strict";
 
-        var events = ['hold','tap','doubletap','transformstart','transform','transformend','dragstart','drag','dragend','swipe','release'];
+	var event_names = ['hold', 'tap', 'doubletap', 'transformstart', 'transform', 'transformend', 'dragstart', 'drag', 'dragend', 'swipe', 'release'],
+		event_name, i, l = event_names.length;
 
-        for(var e=0; e<events.length; e++) {
-            hammer['on'+ events[e]] = (function(el, eventName) {
-                return function(ev) {
-                    el.trigger(jQuery.Event(eventName, ev));
-                };
-            })($el, events[e]);
-        }
-    });
-};
+	for (i = 0; i < l; i++) {
+		event_name = event_names[i];
+
+		(function(event_name) {
+			$.event.special[event_name] = {
+				add : function(e) {
+					var $currentTarget = $(this),
+						$targets = e.selector ? $currentTarget.find(e.selector) : $currentTarget;
+
+					$targets.each(function(index, el) {
+						var hammer = new Hammer(el),
+							$el = $(el);
+
+						$el.data("hammer", hammer);
+
+						hammer['on' + event_name] = (function($el) {
+							return function(event) {
+								$el.trigger($.Event(event_name, event));
+							};
+						}($el));
+					});
+				},
+
+				teardown: function(namespaces) {
+					var $el = $(this);
+
+					$el.data('hammer').destroy();
+					$el.removeData('hammer');
+				}
+			};
+		}(event_name));
+	}
+}(jQuery, Hammer));


### PR DESCRIPTION
Hey,

I think in this way its much more comfortable to use Hammer.js with jQuery elements. I hope you like it.
