### PR TITLE
Fix error when switching from 2 touches drag event to transform

### DIFF
--- a/hammer.js
+++ b/hammer.js
@@ -650,9 +650,18 @@ function Hammer(element, options, undefined)
                 _event_move = event;
                 _pos.move = getXYfromEvent(event);
 
+                // CP
+                // there is an issue here
+                // if a transform is no triggered, it's possible
+                // to have a 2 fingers drag. But if gesture.transform become
+                // valid because of treshold. the dragend will not be triggerd
+                // and worst the _first will not be true and the transformstart
+                // will not be initialized and it will not _pos.startCenter will be 
+                // undefined
                 if(!gestures.transform(event)) {
                     gestures.drag(event);
                 }
+
                 break;
 
             case 'mouseup':


### PR DESCRIPTION
Without my fix it was possible to generate a 2 touches drag event ( which is good ) and enter in to gesture.transform code and generate a transform event without taking care of finishing the drag event.
And because it was not handled it generated an error because the _first was not to true and making the _pos.startCenter = undefined

So I added code to handle correctly the switch from 2 touches drag to transform. It generate the dragend event and take care to set _first to true to handle the first event of transform correctly.
