### PR TITLE
bower update trigger this error

### DIFF
--- a/component.json
+++ b/component.json
@@ -1,5 +1,5 @@
 {
     "name": "hammerjs",
-    "version": "1.0.3dev",
+    "version": "1.0.3",
     "main": ["dist/jquery.hammer.js"]
 }


### PR DESCRIPTION
mismatch The version specified in the component.json of package hammer mismatches the tag (1.0.3 vs 1.0.3dev)
mismatch You should report this problem to the package author
