### PR TITLE
Gesture aborted on different targets

### DIFF
--- a/src/detection.js
+++ b/src/detection.js
@@ -20,7 +20,7 @@ Hammer.detection = {
      */
     startDetect: function startDetect(inst, eventData) {
         // already busy with a Hammer.gesture detection on an element
-        if(this.current) {
+        if(this.current && this.current.lastEvent.target == eventData.target) {
             return;
         }
 


### PR DESCRIPTION
I have a tap gesture on an element and a touchend bind on another element. When the startDetect function is fired, `this.current` contains the data of the touchend but the `if()` statement prevents the new event data to be set.

This is the code I use on the page:

```
$(document.body).hammer().on('tap', '.show-detail', function (e) { ... });
...
$('#container').on('touchend', '.close', function (e) {
    ...
    return false;
});
```

Probably the wrong behavior is caused by the mixture of hammer / non-hammer bindings.
Anyway, the attached code fixes the issue for me.
