### PR TITLE
add support for component as well as bower

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,3 @@
+{
+  "json": "bower.json"
+}

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,5 @@
+{
+    "name": "hammerjs",
+    "version": "1.0.4dev",
+    "main": ["dist/jquery.hammer.js"]
+}

--- a/component.json
+++ b/component.json
@@ -1,5 +1,8 @@
 {
     "name": "hammerjs",
     "version": "1.0.4dev",
-    "main": ["dist/jquery.hammer.js"]
+    "main": "dist/jquery.hammer.js",
+    "scripts": [
+      "dist/jquery.hammer.js"
+    ]
 }


### PR DESCRIPTION
component and bower have different yet very similar specs. fortunately bower allows you to select your own `json` file (they might be switching to bower.json permanently later) and you already have commonjs support, so it shouldn't matter that much.

only downside is that you'll now have to update your version in three places!
