### PR TITLE
Added drag_lock_min_distance

### DIFF
--- a/src/gestures.js
+++ b/src/gestures.js
@@ -250,7 +250,10 @@ Hammer.gestures.Drag = {
         drag_block_vertical     : false,
         // drag_lock_to_axis keeps the drag gesture on the axis that it started on,
         // It disallows vertical directions if the initial direction was horizontal, and vice versa.
-        drag_lock_to_axis       : false
+        drag_lock_to_axis       : false,
+        // drag lock only kicks in when distance > drag_lock_min_distance
+        // This way, locking occurs only when the distance has become large enough to reliably determine the direction
+        drag_lock_min_distance : 25
     },
     triggered: false,
     handler: function dragGesture(ev, inst) {
@@ -285,8 +288,11 @@ Hammer.gestures.Drag = {
                 Hammer.detection.current.name = this.name;
 
                 // lock drag to axis?
+                if(Hammer.detection.current.lastEvent.drag_locked_to_axis || (inst.options.drag_lock_to_axis && inst.options.drag_lock_min_distance<=ev.distance)) {
+                    ev.drag_locked_to_axis = true;
+                }
                 var last_direction = Hammer.detection.current.lastEvent.direction;
-                if(inst.options.drag_lock_to_axis && last_direction !== ev.direction) {
+                if(ev.drag_locked_to_axis && last_direction !== ev.direction) {
                     // keep direction on the axis that the drag gesture started on
                     if(Hammer.utils.isVertical(last_direction)) {
                         ev.direction = (ev.deltaY < 0) ? Hammer.DIRECTION_UP : Hammer.DIRECTION_DOWN;


### PR DESCRIPTION
To avoid locking when the distance is not large enough to reliably determine the direction
