### PR TITLE
hammer.showtouches.js plugin no longer requires jQuery

### DIFF
--- a/plugins/hammer.showtouches.js
+++ b/plugins/hammer.showtouches.js
@@ -21,7 +21,7 @@
             // remove unused touch elements
             for(var key in touch_elements) {
                 if(touch_elements.hasOwnProperty(key) && !touches_index[key]) {
-                    touch_elements[key].remove();
+                    document.body.removeChild(touch_elements[key]);
                     delete touch_elements[key];
                 }
             }


### PR DESCRIPTION
I often work on projects where it is a requirement to not use jQuery. Found this plugin very helpful and modified the jQuery-specific parts to be more raw javascript with cross-browser support in mind. Thought I'd share and contribute! Thanks for hammer!
