### PR TITLE
Added AngularJS module definition to outro.js

### DIFF
--- a/src/outro.js
+++ b/src/outro.js
@@ -2,6 +2,10 @@
 if(typeof module === 'object' && typeof module.exports === 'object'){
     module.exports = Hammer;
 }
+// export as AngularJS injectable module
+else if(typeof angular === 'object') {
+    angular.module('hammer', []).constant('Hammer', Hammer);
+}
 // just window export
 else {
     window.Hammer = Hammer;


### PR DESCRIPTION
AndularJS modules should be loaded through its own Dependency Injection mechanics, and not into global `window` object (global state is prohibited by AngularJS ideology).

More info: http://docs.angularjs.org/guide/di
