### PR TITLE
eliminated references to globals "navigator" and "document".

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -32,12 +32,12 @@ Hammer.defaults = {
 };
 
 // detect touchevents
-Hammer.HAS_POINTEREVENTS = navigator.pointerEnabled || navigator.msPointerEnabled;
+Hammer.HAS_POINTEREVENTS = window.navigator.pointerEnabled || window.navigator.msPointerEnabled;
 Hammer.HAS_TOUCHEVENTS = ('ontouchstart' in window);
 
 // dont use mouseevents on mobile devices
 Hammer.MOBILE_REGEX = /mobile|tablet|ip(ad|hone|od)|android/i;
-Hammer.NO_MOUSEEVENTS = Hammer.HAS_TOUCHEVENTS && navigator.userAgent.match(Hammer.MOBILE_REGEX);
+Hammer.NO_MOUSEEVENTS = Hammer.HAS_TOUCHEVENTS && window.navigator.userAgent.match(Hammer.MOBILE_REGEX);
 
 // eventtypes per touchevent (start, move, end)
 // are filled by Hammer.event.determineEventTypes on setup
@@ -60,7 +60,7 @@ Hammer.EVENT_MOVE = 'move';
 Hammer.EVENT_END = 'end';
 
 // hammer document where the base events are added at
-Hammer.DOCUMENT = document;
+Hammer.DOCUMENT = window.document;
 
 // plugins namespace
 Hammer.plugins = {};


### PR DESCRIPTION
changed to "window.navigator" and "window.document" so that the injected
"window" instance is used.
