### PR TITLE
Fixed stopDefaultBrowserBehavior in Firefox

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -166,7 +166,7 @@ Hammer.utils = {
      */
     stopDefaultBrowserBehavior: function stopDefaultBrowserBehavior(element, css_props) {
         var prop,
-            vendors = ['webkit','khtml','moz','ms','o',''];
+            vendors = ['webkit','khtml','moz','Moz','ms','o',''];
 
         if(!css_props || !element.style) {
             return;


### PR DESCRIPTION
Firefox seems to expect vendor-specific style properties to be prefixed with "Moz" rather than "moz". I'm not sure if this is only  certain versions of Firefox, so I left the old "moz" in there as well.
