### PR TITLE
remove global object when loaded as an AMD module.

### DIFF
--- a/src/outro.js
+++ b/src/outro.js
@@ -1,11 +1,6 @@
 // Based off Lo-Dash's excellent UMD wrapper (slightly modified) - https://github.com/bestiejs/lodash/blob/master/lodash.js#L5515-L5543
 // some AMD build optimizers, like r.js, check for specific condition patterns like the following:
 if(typeof define == 'function' && typeof define.amd == 'object' && define.amd) {
-    // Expose Hammer to the global object even when an AMD loader is present in
-    // case Hammer was injected by a third-party script and not intended to be
-    // loaded as a module.
-    window.Hammer = Hammer;
-
     // define as an anonymous module
     define(function() {
         return Hammer;


### PR DESCRIPTION
avoid dumping global variables in the page:
http://requirejs.org/docs/whyamd.html#youcando
