### PR TITLE
Added interimAngle and interimDirection to event data

### DIFF
--- a/src/detection.js
+++ b/src/detection.js
@@ -124,22 +124,24 @@ Hammer.detection = {
             velocity = Hammer.utils.getVelocity(delta_time, delta_x, delta_y);
 
         Hammer.utils.extend(ev, {
-            deltaTime   : delta_time,
+            deltaTime       : delta_time,
 
-            deltaX      : delta_x,
-            deltaY      : delta_y,
+            deltaX          : delta_x,
+            deltaY          : delta_y,
 
-            velocityX   : velocity.x,
-            velocityY   : velocity.y,
+            velocityX       : velocity.x,
+            velocityY       : velocity.y,
 
-            distance    : Hammer.utils.getDistance(startEv.center, ev.center),
-            angle       : Hammer.utils.getAngle(startEv.center, ev.center),
-            direction   : Hammer.utils.getDirection(startEv.center, ev.center),
+            distance        : Hammer.utils.getDistance(startEv.center, ev.center),
+            angle           : Hammer.utils.getAngle(startEv.center, ev.center),
+            interimAngle    : this.current.lastEvent && Hammer.utils.getAngle(this.current.lastEvent.center, ev.center),
+            direction       : Hammer.utils.getDirection(startEv.center, ev.center),
+            interimDirection: this.current.lastEvent && Hammer.utils.getDirection(this.current.lastEvent.center, ev.center),
 
-            scale       : Hammer.utils.getScale(startEv.touches, ev.touches),
-            rotation    : Hammer.utils.getRotation(startEv.touches, ev.touches),
+            scale           : Hammer.utils.getScale(startEv.touches, ev.touches),
+            rotation        : Hammer.utils.getRotation(startEv.touches, ev.touches),
 
-            startEvent  : startEv
+            startEvent      : startEv
         });
 
         return ev;


### PR DESCRIPTION
Currently the angle and the direction are always relative
to the first event. In practice that means, if one drags
100px to the right and then drags 50px back to the left,
the direction still says "right" even so one is actually
dragging to the left.

This commit adds two properties "interimAngle" and
"interimDirection" to the event object which give information
about the angle and direction relative to the last event instead
of relative to the first event.

Fixes #303
