### PR TITLE
fixed stopDefaultBrowserBehavior userDrag in Firefox

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -199,7 +199,7 @@ Hammer.utils = {
         // and disable ondragstart
         if(css_props.userDrag == 'none') {
             element.ondragstart = function() {
-            	return false;	
+                return false;
             };
         }
     }


### PR DESCRIPTION
Firefox doesn't have a css property for disabling userDrag.
To fix this, we bind the ondragstart event and return false.
