### PR TITLE
Making eventData in trigger function optional

### DIFF
--- a/src/instance.js
+++ b/src/instance.js
@@ -78,6 +78,7 @@ Hammer.Instance.prototype = {
      * @returns {Hammer.Instance}
      */
     trigger: function triggerEvent(gesture, eventData){
+    	if(!eventData){eventData = {};}
         // create DOM event
         var event = Hammer.DOCUMENT.createEvent('Event');
 		event.initEvent(gesture, true, true);


### PR DESCRIPTION
Sometimes I just want to trigger an event, however I cannot without passing an empty object as the second argument, this seems to work well for me in all my cases
