### PR TITLE
fixes undefined window.Hammer var

### DIFF
--- a/dist/jquery.hammer.js
+++ b/dist/jquery.hammer.js
@@ -1547,6 +1547,7 @@ var extendJquery = function(Hammer, $) {
         });
 
     } else {
+        window.Hammer = Hammer;
         extendJquery(window.Hammer, window.jQuery || window.Zepto);
     }
 


### PR DESCRIPTION
fixes undefined window.Hammer var so extendJquery works by assigning window.Hammer to Hammer.

EDIT: Grammar.
