### PR TITLE
Fixes #372

### DIFF
--- a/src/detection.js
+++ b/src/detection.js
@@ -121,7 +121,21 @@ Hammer.detection = {
         var delta_time = ev.timeStamp - startEv.timeStamp,
             delta_x = ev.center.pageX - startEv.center.pageX,
             delta_y = ev.center.pageY - startEv.center.pageY,
-            velocity = Hammer.utils.getVelocity(delta_time, delta_x, delta_y);
+            velocity = Hammer.utils.getVelocity(delta_time, delta_x, delta_y),
+            interimAngle,
+            interimDirection;
+
+        // end events (e.g. dragend) don't have useful values for interimDirection & interimAngle
+        // because the previous event has exactly the same coordinates
+        // so for end events, take the previous values of interimDirection & interimAngle
+        // instead of recalculating them and getting a spurious '0'
+        if (ev.eventType === 'end') {
+            interimAngle = this.current.lastEvent && this.current.lastEvent.interimAngle;
+            interimDirection = this.current.lastEvent && this.current.lastEvent.interimDirection;
+        } else {
+            interimAngle = this.current.lastEvent && Hammer.utils.getAngle(this.current.lastEvent.center, ev.center);
+            interimDirection = this.current.lastEvent && Hammer.utils.getDirection(this.current.lastEvent.center, ev.center);
+        }
 
         Hammer.utils.extend(ev, {
             deltaTime       : delta_time,
@@ -134,9 +148,9 @@ Hammer.detection = {
 
             distance        : Hammer.utils.getDistance(startEv.center, ev.center),
             angle           : Hammer.utils.getAngle(startEv.center, ev.center),
-            interimAngle    : this.current.lastEvent && Hammer.utils.getAngle(this.current.lastEvent.center, ev.center),
+            interimAngle    : interimAngle,
             direction       : Hammer.utils.getDirection(startEv.center, ev.center),
-            interimDirection: this.current.lastEvent && Hammer.utils.getDirection(this.current.lastEvent.center, ev.center),
+            interimDirection: interimDirection,
 
             scale           : Hammer.utils.getScale(startEv.touches, ev.touches),
             rotation        : Hammer.utils.getRotation(startEv.touches, ev.touches),


### PR DESCRIPTION
For end events such as dragend, take interimAngle and interimDirection from the previous event, instead of attempting to recalculate them (which leads to spurious 0 values for each)
