### PR TITLE
Fix for NaN values in ev.gesture.deltaX & ev.gesture.deltaY on IE10 (Win...

### DIFF
--- a/src/gestures.js
+++ b/src/gestures.js
@@ -298,7 +298,7 @@ Hammer.gestures.Drag = {
                 // we are dragging!
                 if(Hammer.detection.current.name != this.name) {
                     Hammer.detection.current.name = this.name;
-                    if (inst.options.correct_for_drag_min_distance) {
+                    if (inst.options.correct_for_drag_min_distance && ev.distance > 0) {
                         // When a drag is triggered, set the event center to drag_min_distance pixels from the original event center.
                         // Without this correction, the dragged distance would jumpstart at drag_min_distance pixels instead of at 0.
                         // It might be useful to save the original start point somewhere


### PR DESCRIPTION
...dows 8 with touch screen), casued by IE10 triggering a touchmove event with unchanged position.
