### PR TITLE
Carousel example: several fixes

### DIFF
--- a/examples/carousel.html
+++ b/examples/carousel.html
@@ -235,8 +235,8 @@
                     var drag_offset = ((100/pane_width)*ev.gesture.deltaX) / pane_count;
 
                     // slow down at the first and last pane
-                    if((current_pane == 0 && ev.gesture.direction == Hammer.DIRECTION_RIGHT) ||
-                        (current_pane == pane_count-1 && ev.gesture.direction == Hammer.DIRECTION_LEFT)) {
+                    if((current_pane == 0 && ev.gesture.direction == "right") ||
+                        (current_pane == pane_count-1 && ev.gesture.direction == "left")) {
                         drag_offset *= .4;
                     }
 


### PR DESCRIPTION
1. Added missing boolean argument to showPane() function inside carousel()
   function, was set to always animate. Already called with the boolean
   argument from carousel.next(), carousel.prev() and
   carousel.handleHammer().
2. Removed undefined constants in handleHammer()
