### PR TITLE
fixed typo, stylistic adjustments

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,1 +1,1 @@
-The demos are for demoing only, and not production ready. Hammer.js is not a component library.
+The demos are for illustration purposes only, and not production ready. Hammer.js is not a component library.


### PR DESCRIPTION
- `s/demo's/demos/`
- rephrased to avoid repetition (feel free to omit this)
