### PR TITLE
Always respect tap_max_distance, not just at the end of the gesture (#406)

### DIFF
--- a/src/gestures/tap.js
+++ b/src/gestures/tap.js
@@ -14,15 +14,17 @@ Hammer.gestures.Tap = {
     doubletap_interval: 300
   },
   handler : function tapGesture(ev, inst) {
-    if(ev.eventType == Hammer.EVENT_END && ev.srcEvent.type != 'touchcancel') {
+    if(ev.eventType == Hammer.EVENT_MOVE && !Hammer.detection.current.reachedTapMaxDistance) {
+      //Track the distance we've moved. If it's above the max ONCE, remember that (fixes #406).
+      Hammer.detection.current.reachedTapMaxDistance = (ev.distance > inst.options.tap_max_distance);
+    } else if(ev.eventType == Hammer.EVENT_END && ev.srcEvent.type != 'touchcancel') {
       // previous gesture, for the double tap since these are two different gesture detections
       var prev = Hammer.detection.previous,
         did_doubletap = false;
 
       // when the touchtime is higher then the max touch time
       // or when the moving distance is too much
-      if(ev.deltaTime > inst.options.tap_max_touchtime ||
-        ev.distance > inst.options.tap_max_distance) {
+      if(Hammer.detection.current.reachedTapMaxDistance || ev.deltaTime > inst.options.tap_max_touchtime) {
         return;
       }
 


### PR DESCRIPTION
Fixes #406

In combination with an increased tap_max_touchtime the current implementation
causes a lot of accidental taps when scrolling back and forth.

This is a very simple fix which tracks the distance during the MOVE event.

*_Note: *_ I needed a solution _now_, that's why I patched hammer. I'm not expecting this to get pulled, I guess adding `reachedTapMaxDistance` to `Hammer.detection.current` is not very elegant. But it works. I hope this helps understanding #406 and solving it nicely.
