### PR TITLE
fix for #433

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -191,7 +191,7 @@ Hammer.event = {
    * @param   {Object}    ev
    */
   normalizeTouchEndTouches: function normalizeTouchEndTouches(ev) {
-    if(ev.type.toLowerCase() != "touchend") {
+    if(ev.type.toLowerCase() != 'touchend') {
       return ev.touches;
     }
 


### PR DESCRIPTION
don't change the value of outer variable eventType
normalize touchend's touches (Firefox OS issue)
