### PR TITLE
More reliable method of `window` obtainment

### DIFF
--- a/src/outro.js
+++ b/src/outro.js
@@ -14,4 +14,6 @@
     window.Hammer = Hammer;
   }
 
-})(window);
+})(function () {
+    return this;
+}());


### PR DESCRIPTION
This is my motivation: I'm using CommonJS modules and in such modules `this` outside functions points to a `module.exports` object, not `global` (or `window`).
