### PR TITLE
Fix pinchzoom example disappearing in IE

### DIFF
--- a/examples/pinchzoom.html
+++ b/examples/pinchzoom.html
@@ -82,7 +82,7 @@
         // transform!
         var transform =
                 "translate3d("+posX+"px,"+posY+"px, 0) " +
-                "scale3d("+scale+","+scale+", 0) " +
+                "scale3d("+scale+","+scale+", 1) " +
                 "rotate("+rotation+"deg) ";
 
         rect.style.transform = transform;


### PR DESCRIPTION
In IE 10/11, setting an element's transform with a scale3d where the
z-axis's scale is 0 will effectively hide the element. This means that
as soon as the picture was touched, the picture would disappear.

Fixes Issue #457

Fix was tested in IE 11 and Chrome 32.0.1700.107.
