### PR TITLE
HAMMER.EVENT_END does reset all pointers

### DIFF
--- a/src/detection.js
+++ b/src/detection.js
@@ -70,7 +70,7 @@ Hammer.detection = {
     }
 
     // endevent, but not the last touch, so dont stop
-    if(eventData.eventType == Hammer.EVENT_END && eventData.touches.length == 1) {
+    if(eventData.eventType == Hammer.EVENT_END && !eventData.touches.length - 1) {
       this.stopDetect();
     }
 


### PR DESCRIPTION
When updating a pointer with a HAMMER.EVENT_END, only remove that pointer from the pointers-object. Previously, a HAMMER.EVENT_END would reset all pointers.
