### PR TITLE
Remove obsolete css rule

### DIFF
--- a/examples/drag.html
+++ b/examples/drag.html
@@ -11,14 +11,6 @@
             text-align: center;
         }
 
-        #playground {
-            position: absolute;
-            top: 0;
-            right: 0;
-            bottom: 0;
-            left: 0;
-        }
-
         .drag {
             position: absolute;
             left: 100px;


### PR DESCRIPTION
# playground wasn't used in this example.
