### PR TITLE
IE7 js error fix

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -348,7 +348,7 @@ var Utils = Hammer.utils = {
      */
     toCamelCase: function toCamelCase(str) {
         return str.replace(/[_-]([a-z])/g, function(s) {
-            return s[1].toUpperCase();
+            return s.charAt(1).toUpperCase();
         });
     }
 };


### PR DESCRIPTION
IE7 doesn't allow access to char in a string using index
