### PR TITLE
Add PanTest & Require Failure Test with Pan & Press recognizers

### DIFF
--- a/tests/unit/gestures/test_pan.js
+++ b/tests/unit/gestures/test_pan.js
@@ -1,0 +1,41 @@
+var el,
+    hammer;
+ 
+ 
+module('Pan Gesture', {
+    setup: function() {
+        el = document.createElement('div');
+        document.body.appendChild(el);
+ 
+        hammer = new Hammer(el, {recognizers: []});
+    },
+    teardown: function() {
+        document.body.removeChild(el);
+        hammer.destroy();
+    }
+});
+ 
+test('`panstart` and `panmove` should be recognized', function() {
+ 
+    expect(2);
+ 
+    var panMoveCount = 0;
+    var pan = new Hammer.Pan({threshold: 1});
+ 
+    hammer.add(pan);
+ 
+    hammer.on('panstart', function() {
+      ok(true);
+    });
+    hammer.on('panmove', function() {
+      panMoveCount++;
+    });
+ 
+ 
+    utils.dispatchTouchEvent(el, 'start', 50, 50);
+    utils.dispatchTouchEvent(el, 'move', 70, 50);
+    utils.dispatchTouchEvent(el, 'move', 90, 50);
+    
+    equal(panMoveCount, 1);
+ 
+});

--- a/tests/unit/index.html
+++ b/tests/unit/index.html
@@ -32,6 +32,7 @@
 <script src="test_require_failure.js"></script>
 
 <script src="test_jquery_plugin.js"></script>
+<script src="gestures/test_pan.js"></script>
 
 </body>
 </html>

--- a/tests/unit/test_require_failure.js
+++ b/tests/unit/test_require_failure.js
@@ -3,6 +3,7 @@ var el,
     pressPeriod = 200,
     pressThreshold = 20,
     pressCount = 0,
+    panStartCount = 0,
     swipeCount = 0;
 
 module('Require Failure ( Swipe & Press )', {
@@ -53,4 +54,59 @@ asyncTest('When swipe does recognize the gesture, a press gesture cannot be fire
         ok(swipeCount > 0, 'swipe gesture should be recognizing');
         equal(pressCount, 0, 'press gesture should not be recognized because swipe gesture is recognizing');
     });
+});
+module('Require Failure ( Pan & Press )', {
+    setup: function() {
+        el = document.createElement('div');
+        document.body.appendChild(el);
+ 
+        hammer = new Hammer(el, {recognizers: []});
+ 
+        var pan = new Hammer.Pan({threshold: 1});
+        var press = new Hammer.Press({time: pressPeriod, threshold: pressThreshold});
+ 
+        hammer.add(pan);
+        hammer.add(press);
+ 
+        pan.recognizeWith(press);
+        press.requireFailure(pan);
+ 
+        pressCount = 0;
+        panStartCount = 0;
+        hammer.on('press', function() {
+            pressCount++;
+        });
+        hammer.on('panstart', function() {
+            panStartCount++;
+        });
+    },
+    teardown: function() {
+        document.body.removeChild(el);
+        hammer.destroy();
+    }
+});
+ 
+asyncTest('When pan does not recognize the gesture, a press gesture can be fired', function() {
+    expect(1);
+ 
+    utils.dispatchTouchEvent(el, 'start', 50, 50);
+ 
+    setTimeout(function() {
+        start();
+        equal(pressCount, 1);
+    }, pressPeriod + 100);
+});
+ 
+asyncTest('When pan recognizes the gesture, a press gesture cannot be fired', function() {
+    expect(2);
+ 
+    utils.dispatchTouchEvent(el, 'start', 50, 50);
+    utils.dispatchTouchEvent(el, 'move', 50 + pressThreshold / 4, 50);
+ 
+    setTimeout(function() {
+        start();
+ 
+        ok(panStartCount > 0, 'pan gesture should be recognizing');
+        equal(pressCount, 0, 'press gesture should not be recognized because pan gesture is recognizing');
+    }, pressPeriod + 100);
 });


### PR DESCRIPTION
Add some tests:
- A pan gesture should be recognized when the event is fired with the method `utils.dispatchTouchEvent`.
- Add a test to simulate a Require Failure Scenario with Pan & Press recognizers on the same element.
