### PR TITLE
Add grunt task `default-test`

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -108,6 +108,7 @@ module.exports = (grunt) ->
 
   # Default task(s)
   grunt.registerTask 'default', ['connect','watch']
+  grunt.registerTask 'default-test', ['connect', 'uglify:test','watch']
   grunt.registerTask 'build', ['concat','string-replace','uglify:min','test']
   grunt.registerTask 'test', ['jshint','jscs','uglify:test','qunit']
   grunt.registerTask 'test-travis', ['build']


### PR DESCRIPTION
This task allows running the test suite in browser environment. 

grunt `default` was used before, but it didn't always work.
