### PR TITLE
fix event handling.

### DIFF
--- a/src/manager.js
+++ b/src/manager.js
@@ -210,10 +210,10 @@ Manager.prototype = {
         }
 
         // no handlers, so skip it all
-        if (!this.handlers[event] || !this.handlers[event].length) {
+        var handlers = this.handlers[event] && this.handlers[event].slice();
+        if (!handlers || !handlers.length) {
             return;
         }
-        var handlers = this.handlers[event].slice();
 
         data.type = event;
         data.preventDefault = function() {


### PR DESCRIPTION
Calling `hammer.off(...)` in an event handler can lead to a "cannot call method of undefined" error in the for loop on line 233. This is because `var handlers` refers to the same object as `this.handlers` does. Using `Array.slice()` solves this issue. 
