### PR TITLE
Fix requireFailure() call in manager

### DIFF
--- a/src/manager.js
+++ b/src/manager.js
@@ -26,7 +26,7 @@ function Manager(element, options) {
     each(options.recognizers, function(item) {
         var recognizer = this.add(new (item[0])(item[1]));
         item[2] && recognizer.recognizeWith(item[2]);
-        item[3] && recognizer.requireFailure(item[2]);
+        item[3] && recognizer.requireFailure(item[3]);
     }, this);
 }
 

--- a/tests/unit/test_hammer.js
+++ b/tests/unit/test_hammer.js
@@ -121,3 +121,25 @@ asyncTest('Should detect input while on other element', function() {
         start();
     });
 });
+
+/* Hammer.Manager constructor accepts a "recognizers" option in which each
+ * element is an array representation of a Recognizer.
+ */
+test('Hammer.Manager accepts recognizers as arrays.', function() {
+    expect(4);
+
+    hammer = new Hammer.Manager(el, {
+        recognizers: [
+            [Hammer.Swipe],
+            [Hammer.Pinch],
+            [Hammer.Rotate],
+            [Hammer.Pan, { direction: Hammer.DIRECTION_UP }, ['swipe', 'pinch'], ['rotate']]
+        ]
+    });
+    equal(4, hammer.recognizers.length);
+
+    var recognizerActual = hammer.recognizers[3];
+    equal(recognizerActual.options.direction, Hammer.DIRECTION_UP);
+    equal(2, Object.keys(recognizerActual.simultaneous).length);
+    equal(1, recognizerActual.requireFail.length);
+});


### PR DESCRIPTION
Entirely unsure about the test :)
- Rather compare the _actual_ recognizer objects? But then where to retrieve them from, as they are _created_ in the constructor..
- Rather try to mock `recognizeWith` and `requireFailure`?
