### PR TITLE
Swipe threshold had no effect

### DIFF
--- a/src/recognizers/swipe.js
+++ b/src/recognizers/swipe.js
@@ -39,6 +39,7 @@ inherit(SwipeRecognizer, AttrRecognizer, {
 
         return this._super.attrTest.call(this, input) &&
             direction & input.direction &&
+            input.distance > this.options.threshold &&
             abs(velocity) > this.options.velocity && input.eventType & INPUT_END;
     },
 


### PR DESCRIPTION
The `threshold` option for `Swipe` had no effect. [Live example](http://codepen.io/anon/pen/qBgCy).

Added a one-liner that compares `input.distance` to `options.threshold`.
