### PR TITLE
Fixing pointer events bug falsely detecting multiple pointers

### DIFF
--- a/src/input/pointerevent.js
+++ b/src/input/pointerevent.js
@@ -52,16 +52,20 @@ inherit(PointerEventInput, Input, {
 
         var isTouch = (pointerType == INPUT_TYPE_TOUCH);
 
+        // get index of the event in the store
+        var storeIndex = inArray(store, ev.pointerId, 'pointerId');
+
         // start and mouse must be down
         if (eventType & INPUT_START && (ev.button === 0 || isTouch)) {
-            store.push(ev);
+            if (storeIndex < 0) {
+                store.push(ev);
+                storeIndex = store.length - 1;
+            }
         } else if (eventType & (INPUT_END | INPUT_CANCEL)) {
             removePointer = true;
         }
 
-        // get index of the event in the store
         // it not found, so the pointer hasn't been down (so it's probably a hover)
-        var storeIndex = inArray(store, ev.pointerId, 'pointerId');
         if (storeIndex < 0) {
             return;
         }


### PR DESCRIPTION
It is possible for IE to fire a "down" event without a corresponding "up"
event. If this happens, a new "down" event will be falsely added as an
additional pointer. This commit first makes sure the pointer from the
down event is not already in the store before adding it (based on
pointerId).

Fixes #664
