### PR TITLE
list the 'pinch' event in code comments

### DIFF
--- a/src/gestures/transform.js
+++ b/src/gestures/transform.js
@@ -22,6 +22,10 @@
  * @param {Object} ev
  */
 /**
+ * @event pinch
+ * @param {Object} ev
+ */
+/**
  * @event pinchin
  * @param {Object} ev
  */


### PR DESCRIPTION
Has `'pinch'` been accidentally omitted from the in-code comments?

```javascript
if(scaleThreshold > inst.options.transformMinScale) {
    inst.trigger('pinch', ev);  // <<--- `pinch` event, HERE !
    inst.trigger('pinch' + (ev.scale < 1 ? 'in' : 'out'), ev);
}
```