### PR TITLE
Add Meteor.js support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,11 @@ node_js:
 
 before_script:
   - npm install -g grunt-cli
+  # Install meteor
+  - curl https://install.meteor.com | /bin/sh
+  # Install spacejam, Meteor's CI helper
+  - npm install -g spacejam
 
 script:
   - grunt test-travis
+  - grunt meteor-test

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -96,11 +96,29 @@ module.exports = (grunt) ->
     connect:
       server:
         options:
-          hostname: "0.0.0.0"
+          hostname: '0.0.0.0'
           port: 8000
 
     qunit:
       all: ['tests/unit/index.html']
+
+    exec:
+      'meteor-init':
+        command: [
+          # Make sure Meteor is installed, per https://meteor.com/install.
+          # The curl'ed script is safe; takes 2 minutes to read source & check.
+          'type meteor >/dev/null 2>&1 || { curl https://install.meteor.com/ | sh; }',
+          # Meteor expects package.js to be in the root directory
+          # of the checkout, so copy it there temporarily
+          'cp meteor/package.js .'
+        ].join(';')
+      'meteor-cleanup':
+        # remove build files and package.js
+        command: 'rm -rf .build.* versions.json package.js'
+      'meteor-test':
+        command: 'node_modules/.bin/spacejam --mongo-url mongodb:// test-packages ./'
+      'meteor-publish':
+        command: 'meteor publish'
 
 
   # Load tasks
@@ -113,6 +131,7 @@ module.exports = (grunt) ->
   grunt.loadNpmTasks 'grunt-string-replace'
   grunt.loadNpmTasks 'grunt-banner'
   grunt.loadNpmTasks 'grunt-jscs'
+  grunt.loadNpmTasks 'grunt-exec'
 
   # Default task(s)
   grunt.registerTask 'default', ['connect', 'watch']
@@ -120,3 +139,8 @@ module.exports = (grunt) ->
   grunt.registerTask 'build', ['concat', 'string-replace', 'uglify:min', 'usebanner', 'test']
   grunt.registerTask 'test', ['jshint', 'jscs', 'uglify:test', 'qunit']
   grunt.registerTask 'test-travis', ['build']
+
+  # Meteor tasks
+  grunt.registerTask 'meteor-test', ['exec:meteor-init', 'exec:meteor-test', 'exec:meteor-cleanup']
+  grunt.registerTask 'meteor-publish', ['exec:meteor-init', 'exec:meteor-publish', 'exec:meteor-cleanup']
+  grunt.registerTask 'meteor', ['exec:meteor-init', 'exec:meteor-test', 'exec:meteor-publish', 'exec:meteor-cleanup']

--- a/meteor/README.md
+++ b/meteor/README.md
@@ -1,0 +1,27 @@
+[![Build Status](https://travis-ci.org/MeteorPackaging/hammer.js.svg?branch=master)](https://travis-ci.org/MeteorPackaging/hammer.js)
+
+Packaging [Hammer.js](http://hammerjs.github.io/) for [Meteor.js](http://meteor.com).
+
+
+# Meteor
+
+If you're new to Meteor, here's what the excitement is all about -
+[watch the first two minutes](https://www.youtube.com/watch?v=fsi0aJ9yr2o); you'll be hooked by 1:28.
+
+That screencast is from 2012. In the meantime, Meteor has become a mature JavaScript-everywhere web
+development framework. Read more at [Why Meteor](http://www.meteorpedia.com/read/Why_Meteor).
+
+
+# Issues
+
+If you encounter an issue while using this package, please CC @dandv when you file it in this repo.
+
+
+# DONE
+
+* Instantiation test
+
+
+# TODO
+
+* Tests ensuring correct event handling on template re-rendering

--- a/meteor/export.js
+++ b/meteor/export.js
@@ -1,0 +1,3 @@
+/*global Hammer:true*/  // Meteor creates a file-scope global for exporting. This comment prevents a potential JSHint warning.
+Hammer = window.Hammer;
+delete window.Hammer;

--- a/meteor/package.js
+++ b/meteor/package.js
@@ -1,0 +1,31 @@
+// package metadata file for Meteor.js
+'use strict';
+
+var packageName = 'hammer:hammer';  // https://atmospherejs.com/hammer/hammer
+var where = 'client';  // where to install: 'client' or 'server'. For both, pass nothing.
+
+var packageJson = JSON.parse(Npm.require("fs").readFileSync('package.json'));
+
+Package.describe({
+  name: packageName,
+  summary: 'Hammer.js (official) - multi-touch/mouse gestures: tap, pan, press, swipe, pinch, rotate',
+  version: packageJson.version,
+  git: 'https://github.com/hammerjs/hammer.js.git'
+});
+
+Package.onUse(function (api) {
+  api.versionsFrom(['METEOR@0.9.0', 'METEOR@1.0']);
+  api.export('Hammer');
+  api.addFiles([
+    'hammer.js',
+    'meteor/export.js'
+  ], where
+  );
+});
+
+Package.onTest(function (api) {
+  api.use(packageName, where);
+  api.use('tinytest', where);
+
+  api.addFiles('meteor/test.js', where);
+});

--- a/meteor/test.js
+++ b/meteor/test.js
@@ -1,0 +1,8 @@
+'use strict';
+
+Tinytest.add('Hammer.is', function (test) {
+  var div = document.createElement('div');
+  var mc = new Hammer(div);
+  test.instanceOf(mc, Hammer.Manager, 'Instantiation OK');
+  test.instanceOf(mc.get('pinch').manager, Hammer.Manager, 'Default pinch recognizer OK');
+});

--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
     "grunt-contrib-watch": "0.6.x",
     "grunt-jscs": "^0.8.0",
     "grunt-string-replace": "^0.2.7",
+    "grunt-exec": "^0.4.6",
+    "spacejam": "^1.1.1",
     "jquery-hammerjs": "2.0.x",
     "hammer-simulator": "git://github.com/hammerjs/simulator#master"
   },


### PR DESCRIPTION
Hi Jorik,

I'm a Meteor.js dev and volunteer package maintainer for [Meteor](http://meteor.com). Hammer is a great multi-touch library, and adding it to Meteor's ecosystem will expose it to many new devs (Meteor has 20k+ stars on GitHub), likely bringing in new testers and contributors.

This PR will let you directly publish updated versions of the library as they become available. All you have to do is create an account at https://meteor.com/ (click *SIGN IN*, then *Create account*). After you've done that, please let me know the name of the account, and I'll add you as a maintainer.

I've already published the current version of the package on [Atmosphere](https://atmospherejs.com/hammer/hammer) (Meteor's package directory). When you release new versions, you can publish them to Atmosphere with `grunt meteor`.

Thanks & best regards,
Dan, [Meteor integrations team](https://github.com/raix/Meteor-community-discussions/issues/14)