### PR TITLE
Makes minified Hammer work in IE8

### DIFF
--- a/src/setup.js
+++ b/src/setup.js
@@ -17,9 +17,9 @@
  * @param {Object} [options={}]
  * @return {Hammer.Instance}
  */
-var Hammer = function Hammer(element, options) {
+function Hammer(element, options) {
     return new Hammer.Instance(element, options || {});
-};
+}
 
 /**
  * version, as defined in package.json


### PR DESCRIPTION
Both naming a function and storing it in a variable with the same name breaks scripts in IE8 when minified by for example uglify2. There is no need to name the function two times so this commit removes the "var Hammer = " part.

Resolves https://github.com/hammerjs/jquery.hammer.js/issues/20