### PR TITLE
Changing direction during pan not recognised

### DIFF
--- a/src/input.js
+++ b/src/input.js
@@ -205,8 +205,10 @@ function computeDeltaXY(session, input) {
         };
     }
 
-    input.deltaX = prevDelta.x + (center.x - offset.x);
-    input.deltaY = prevDelta.y + (center.y - offset.y);
+    input.deltaX = (center.x - offset.x) - prevDelta.x;
+    input.deltaY = (center.y - offset.y) - prevDelta.y;
+    prevDelta.x = (center.x - offset.x);
+    prevDelta.y = (center.y - offset.y);
 }
 
 /**


### PR DESCRIPTION
Fix for changing direction during pan not being recognised.

e.g. [http://stackoverflow.com/questions/21905554/detect-the-direction-change-on-hammer-js-event](http://stackoverflow.com/questions/21905554/detect-the-direction-change-on-hammer-js-event)

Currently deltaX and deltaY don't reverse until the input passes the start of pan