### PR TITLE
Add the element to the event object (#653)

### DIFF
--- a/src/input.js
+++ b/src/input.js
@@ -178,6 +178,8 @@ function computeInputData(manager, input) {
     input.rotation = firstMultiple ? getRotation(firstMultiple.pointers, pointers) : 0;
 
     computeIntervalInputData(session, input);
+    
+    input.element = manager.element;
 
     // find the correct target
     var target = manager.element;


### PR DESCRIPTION
Always have the element available in the event object as the target can sometimes be the child of the element. Linked to issue #653