### PR TITLE
Recognize singe touch gestures when the touch-action property is set to none.

### DIFF
--- a/src/touchaction.js
+++ b/src/touchaction.js
@@ -83,6 +83,19 @@ TouchAction.prototype = {
         var hasPanY = inStr(actions, TOUCH_ACTION_PAN_Y);
         var hasPanX = inStr(actions, TOUCH_ACTION_PAN_X);
 
+
+        if (hasNone) {
+            //do not prevent defaults if this is a tap gesture
+
+            var isTapPointer = input.pointers.length === 1;
+            var isTapMovement = input.distance === 0;
+            var isTapTouchTime = input.deltaTime < 250;
+
+            if (isTapPointer && isTapMovement && isTapTouchTime) {
+                return;
+            }
+        }
+
         if (hasNone ||
             (hasPanY && direction & DIRECTION_HORIZONTAL) ||
             (hasPanX && direction & DIRECTION_VERTICAL)) {


### PR DESCRIPTION
Hammer js has a bug in the way it determines if it is acceptable to prevent the browser default behavior of scrolling/zoom etc when the touch-action property is set to none and the browser does not provide native support for the touch-action property. It fails to differentiate between a tap gesture and a multi-touch gesture which results in click and hover events from not getting recognized when an element has multi-touch gesture associated with it.