### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,12 +4,7 @@
   "description": "A javascript library for multi-touch gestures",
   "version": "2.0.4",
   "homepage": "http://hammerjs.github.io/",
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/hammerjs/hammer.js/blob/master/LICENSE.md"
-    }
-  ],
+  "license": "MIT",
   "keywords": [
     "touch",
     "gestures"


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/