### PR TITLE
Suggest change event flow

### DIFF
--- a/src/recognizer.js
+++ b/src/recognizer.js
@@ -171,20 +171,24 @@ Recognizer.prototype = {
         var self = this;
         var state = this.state;
 
-        function emit(withState) {
-            self.manager.emit(self.options.event + (withState ? stateStr(state) : ''), input);
+        function emit(event) {
+            self.manager.emit(event, input);
         }
 
         // 'panstart' and 'panmove'
         if (state < STATE_ENDED) {
-            emit(true);
+            emit(self.options.event + stateStr(state));
         }
 
-        emit(); // simple 'eventName' events
+        emit(self.options.event); // simple 'eventName' events
+
+        if (input.additionalEvent) { // additional event(panleft, panright, pinchin, pinchout...)
+            emit(input.additionalEvent);
+        }
 
         // panend and pancancel
         if (state >= STATE_ENDED) {
-            emit(true);
+            emit(self.options.event + stateStr(state));
         }
     },
 

--- a/src/recognizers/pan.js
+++ b/src/recognizers/pan.js
@@ -65,14 +65,15 @@ inherit(PanRecognizer, AttrRecognizer, {
     },
 
     emit: function(input) {
+
         this.pX = input.deltaX;
         this.pY = input.deltaY;
 
         var direction = directionStr(input.direction);
-        if (direction) {
-            this.manager.emit(this.options.event + direction, input);
-        }
 
+        if (direction) {
+            input.additionalEvent = this.options.event + direction;
+        }
         this._super.emit.call(this, input);
     }
 });

--- a/src/recognizers/pinch.js
+++ b/src/recognizers/pinch.js
@@ -29,10 +29,10 @@ inherit(PinchRecognizer, AttrRecognizer, {
     },
 
     emit: function(input) {
-        this._super.emit.call(this, input);
         if (input.scale !== 1) {
             var inOut = input.scale < 1 ? 'in' : 'out';
-            this.manager.emit(this.options.event + inOut, input);
+            input.additionalEvent = this.options.event + inOut;
         }
+        this._super.emit.call(this, input);
     }
 });

--- a/tests/unit/gestures/test_pan.js
+++ b/tests/unit/gestures/test_pan.js
@@ -34,3 +34,30 @@ test('`panstart` and `panmove` should be recognized', function() {
 
     equal(panMoveCount, 1);
 });
+
+asyncTest('Pan event flow should be start -> left -> end', function() {
+    expect(1);
+    var pan = new Hammer.Pan({threshold: 1});
+    hammer.add(pan);
+
+    var eventflow = "";
+    var isCalledPanleft = false;
+    hammer.on('panstart', function() {
+        eventflow += "start";
+    });
+    hammer.on('panleft', function() {
+        if(!isCalledPanleft){
+            isCalledPanleft = true;
+            eventflow += "left";
+        }
+    });
+    hammer.on('panend', function() {
+        eventflow += "end";
+        isCalledPanleft = true;
+    });
+
+    Simulator.gestures.pan(el, { deltaX: -100, deltaY: 0 }, function() {
+        equal(eventflow,"startleftend");
+        start();
+    });
+});

--- a/tests/unit/gestures/test_pinch.js
+++ b/tests/unit/gestures/test_pinch.js
@@ -1,0 +1,43 @@
+var el,
+    hammer;
+
+module('Pinch Gesture', {
+    setup: function() {
+        el = document.createElement('div');
+        document.body.appendChild(el);
+
+        hammer = new Hammer(el, {recognizers: []});
+    },
+    teardown: function() {
+        document.body.removeChild(el);
+        hammer.destroy();
+    }
+});
+
+asyncTest('Pinch event flow should be start -> in -> end', function() {
+    expect(1);
+    var pinch = new Hammer.Pinch({enable: true, threshold: .1});
+    hammer.add(pinch);
+
+    var eventflow = "";
+    var isFiredPinchin = false;
+    hammer.on('pinchstart', function() {
+        eventflow += "start";
+    });
+    hammer.on('pinchin', function() {
+        if(!isFiredPinchin){
+            isFiredPinchin = true;
+            eventflow += "in";
+        }
+    });
+    hammer.on('pinchend', function() {
+        eventflow += "end";
+        isFiredPinchin = false;
+    });
+
+    Simulator.gestures.pinch(el, { duration: 500, scale: .5 }, function() {
+        equal(eventflow,"startinend");
+        start();
+    });
+});
+

--- a/tests/unit/index.html
+++ b/tests/unit/index.html
@@ -36,6 +36,7 @@
 
 <script src="test_jquery_plugin.js"></script>
 <script src="gestures/test_pan.js"></script>
+<script src="gestures/test_pinch.js"></script>
 <script src="gestures/test_swipe.js"></script>
 
 </body>


### PR DESCRIPTION
Hi.
I suggest change event flow.

The PanRecognizer have "pan(start|move|end|cancel)" and "pan(left|right|up|down)" event. The PinchRecognizer have "pinch(start|move|end|cancel)" and "pinch(in|out)" event.

The "emit" method of Recognizer is fire "pan(start|move|end|cancel)", "pinch(start|move|end|cancel)".The "emit" method of Manager is fire "pan(left|right|up|down)", "pinch(in|out)" .

The "emit" method of PanRecognizer call step is
	1. Manager#emit call
	2. Recognizer#emit call
So. The event flow of PanRecognizer is "pan(left|right|up|down) -> panstart -> (left|right|up|down) ....-> panend".

The "emit" method of PinchRecognizer call step is
	1. Recognizer#emit call
	2. Manager#emit call
So. The event flow of PinchRecognizer is "pinchstart -> pinch(in|out) .... -> pinchend -> pinch(in|out)".

Event flow is different from each other. [[sample]](http://codepen.io/mixed/full/rVJwpr/)

I suggest that same event flow.
```
"pinchstart -> pinch(in|out) .... -> pinchend"
"panstart -> pan(left|right|up|down) ....-> panend"
```