### PR TITLE
Fix erroneous `pan-x pan-y` use and handling

### DIFF
--- a/src/recognizers/pan.js
+++ b/src/recognizers/pan.js
@@ -27,10 +27,10 @@ inherit(PanRecognizer, AttrRecognizer, {
         var direction = this.options.direction;
         var actions = [];
         if (direction & DIRECTION_HORIZONTAL) {
-            actions.push(TOUCH_ACTION_PAN_X);
+            actions.push(TOUCH_ACTION_PAN_Y);
         }
         if (direction & DIRECTION_VERTICAL) {
-            actions.push(TOUCH_ACTION_PAN_Y);
+            actions.push(TOUCH_ACTION_PAN_X);
         }
         return actions;
     },

--- a/src/touchaction.js
+++ b/src/touchaction.js
@@ -95,6 +95,11 @@ TouchAction.prototype = {
             }
         }
 
+        if (hasPanX && hasPanY) {
+            // `pan-x pan-y` means browser handles all scrolling/panning, do not prevent
+            return;
+        }
+
         if (hasNone ||
             (hasPanY && direction & DIRECTION_HORIZONTAL) ||
             (hasPanX && direction & DIRECTION_VERTICAL)) {

--- a/src/touchaction.js
+++ b/src/touchaction.js
@@ -126,9 +126,12 @@ function cleanTouchActions(actions) {
     var hasPanX = inStr(actions, TOUCH_ACTION_PAN_X);
     var hasPanY = inStr(actions, TOUCH_ACTION_PAN_Y);
 
-    // pan-x and pan-y can be combined
+    // if both pan-x and pan-y are set (different recognizers
+    // for different directions, e.g. horizontal pan but vertical swipe?)
+    // we need none (as otherwise with pan-x pan-y combined none of these
+    // recognizers will work, since the browser would handle all panning
     if (hasPanX && hasPanY) {
-        return TOUCH_ACTION_PAN_X + ' ' + TOUCH_ACTION_PAN_Y;
+        return TOUCH_ACTION_NONE;
     }
 
     // pan-x OR pan-y

--- a/tests/manual/touchaction.html
+++ b/tests/manual/touchaction.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1, maximum-scale=1">
+    <meta name="viewport" content="width=device-width">
     <link rel="stylesheet" href="assets/style.css">
     <title>Hammer.js</title>
 

--- a/tests/manual/touchaction.html
+++ b/tests/manual/touchaction.html
@@ -47,7 +47,7 @@
         <div class="tester azure" id="auto"></div>
 
         <h2>touch-action: pan-y</h2>
-        <p>Should prevent scrolling on horizontal movement. This is set by default when creating an Hammer instance.</p>
+        <p>Should prevent scrolling on horizontal movement. This is set by default when creating a Hammer instance.</p>
         <div class="tester azure" id="pan-y"></div>
 
         <h2>touch-action: pan-x</h2>
@@ -55,7 +55,7 @@
         <div class="tester azure" id="pan-x"></div>
 
         <h2>touch-action: pan-x pan-y</h2>
-        <p>Should prevent scrolling on all movement.</p>
+        <p>Should <strong>not</strong> prevent any scrolling on any movement. Horizontal and vertical scrolling handled by the browser directly.</p>
         <div class="tester azure" id="pan-x-pan-y"></div>
 
         <h2>touch-action: none</h2>


### PR DESCRIPTION
The `touch-action` property determines which default actions the browser should take. For instance, `touch-action: pan-x` means that the browser will only handle horizontal scrolling itself, while `touch-action: pan-y` means the browser will handle vertical scrolling.

In the `touch-action` logic for the pan recognizer, this logic seems to have been turned around. Currently, with `DIRECTION_VERTICAL`, it wants to set `TOUCH_ACTION_Y` - but this wouldn't work in practice, as this instructs the browser to handle vertical scrolling...and it's exactly that kind of movement we do want to intercept outselves. And vice-versa, for `DIRECTION_HORIZONTAL`, the script sets `TOUCH_ACTION_X`. The fact that these still seem to work in practice (in certain conditions) seems due to additional logic which then combines/modifies the overall `touch-action` value further...however, this PR fixes the problem at the source.

A further issue currently seems to be a misunderstanding of what `touch-action: pan-x pan-y` means - in essence, this value tells the browser to directly handle horizontal and vertical scrolling. It is exactly the same as `touch-action: auto`. However, both in the script logic and the manual test case, it seems the author made the assumption that `touch-action: pan-x pan-y` had the opposite effect of *stopping* the browser from handling these. That is incorrect.

The modified script from this PR was tested on a Surface 3 (with touchscreen) in IE11 and Microsoft Edge, which support native pointer events (and therefore respond to the `touch-action` directive; further testing done in Google Chrome and Firefox, which use the `touch-action` polyfill code. On mobile, this was tested on iOS9/Safari.