### PR TITLE
fix(MSPointerEvent): uses PointerEvent instead of MSPointerEvent

### DIFF
--- a/src/input/pointerevent.js
+++ b/src/input/pointerevent.js
@@ -18,7 +18,7 @@ var POINTER_ELEMENT_EVENTS = 'pointerdown';
 var POINTER_WINDOW_EVENTS = 'pointermove pointerup pointercancel';
 
 // IE10 has prefixed support, and case-sensitive
-if (window.MSPointerEvent) {
+if (window.MSPointerEvent && !window.PointerEvent) {
     POINTER_ELEMENT_EVENTS = 'MSPointerDown';
     POINTER_WINDOW_EVENTS = 'MSPointerMove MSPointerUp MSPointerCancel';
 }


### PR DESCRIPTION
Uses PointerEvent instead of MSPointerEvent if supported.  Fixes #753 