### PR TITLE
fix(moz-prefix): prefix should be Moz not moz.

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,4 @@
-var VENDOR_PREFIXES = ['', 'webkit', 'moz', 'MS', 'ms', 'o'];
+var VENDOR_PREFIXES = ['', 'webkit', 'Moz', 'MS', 'ms', 'o'];
 var TEST_ELEMENT = document.createElement('div');
 
 var TYPE_FUNCTION = 'function';


### PR DESCRIPTION
Fixes #754 