### PR TITLE
fix remove non-existant recognizer

### DIFF
--- a/src/manager.js
+++ b/src/manager.js
@@ -171,11 +171,19 @@ Manager.prototype = {
             return this;
         }
 
-        var recognizers = this.recognizers;
         recognizer = this.get(recognizer);
-        recognizers.splice(inArray(recognizers, recognizer), 1);
 
-        this.touchAction.update();
+        // let's make sure this recognizer exists
+        if (recognizer) {
+            var recognizers = this.recognizers;
+            var index = inArray(recognizers, recognizer);
+
+            if (index !== -1) {
+                recognizers.splice(index, 1);
+                this.touchAction.update();
+            }
+        }
+
         return this;
     },
 

--- a/tests/unit/test_hammer.js
+++ b/tests/unit/test_hammer.js
@@ -143,3 +143,17 @@ test('Hammer.Manager accepts recognizers as arrays.', function() {
     equal(2, Object.keys(recognizerActual.simultaneous).length);
     equal(1, recognizerActual.requireFail.length);
 });
+
+/*
+ * Removing a recognizer which cannot be found would errantly remove the last recognizer in the
+ * manager's list.
+ */
+test('Remove non-existent recognizer.', function() {
+    expect(1);
+
+    hammer = new Hammer(el, {recognizers: []});
+    hammer.add(new Hammer.Swipe());
+    hammer.remove('tap');
+
+    equal(1, hammer.recognizers.length);
+});


### PR DESCRIPTION
* When removing a recognizer, make sure it exists before removal. If recognizer has not been registered to manager inArray will return -1. The negative index passed to Array.splice will remove last element of the recognizers array.