### PR TITLE
chore(bower): make bower ignore config files

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,6 +3,13 @@
     "main": "hammer.js",
     "ignore": [
         "tests",
-        "src"
+        "src",
+        ".gitignore",
+        ".jscsrc",
+        ".jshintrc",
+        ".travis.yml",
+        "component.json",
+        "Gruntfile.coffee",
+        "package.json"
     ]
 }

--- a/bower.json
+++ b/bower.json
@@ -4,6 +4,7 @@
     "ignore": [
         "tests",
         "src",
+        ".bowerrc",
         ".gitignore",
         ".jscsrc",
         ".jshintrc",


### PR DESCRIPTION
reasons for this:
- people who would need these files would `git clone` rather than `bower install`
- consumers would download and install the package a little faster
- in the long run, it may save much bandwidth (a few kb saved per install multiplied by a large amount of installs)