### PR TITLE
feat: make the event compute interval configurable as a manager option

### DIFF
--- a/src/hammer.js
+++ b/src/hammer.js
@@ -20,6 +20,15 @@ Hammer.VERSION = '{{PKG_VERSION}}';
  * @namespace
  */
 Hammer.defaults = {
+
+    /**
+     * The minimum interval (in ms) between two events for them to be considered as separate.
+     * Increasing this may improve event detection correctness on lower-end browsers.
+     * @type {Integer}     
+     * @default 25
+     */
+    computeInterval: COMPUTE_INTERVAL,
+
     /**
      * set if DOM events are being triggered.
      * But this is slower and unused by simple implementations, so disabled by default.

--- a/src/input.js
+++ b/src/input.js
@@ -185,7 +185,7 @@ function computeInputData(manager, input) {
     input.maxPointers = !session.prevInput ? input.pointers.length : ((input.pointers.length >
         session.prevInput.maxPointers) ? input.pointers.length : session.prevInput.maxPointers);
 
-    computeIntervalInputData(session, input);
+    computeIntervalInputData(session, input, manager.options.computeInterval);
 
     // find the correct target
     var target = manager.element;
@@ -222,12 +222,12 @@ function computeDeltaXY(session, input) {
  * @param {Object} session
  * @param {Object} input
  */
-function computeIntervalInputData(session, input) {
+function computeIntervalInputData(session, input, computeInterval) {
     var last = session.lastInterval || input,
         deltaTime = input.timeStamp - last.timeStamp,
         velocity, velocityX, velocityY, direction;
 
-    if (input.eventType != INPUT_CANCEL && (deltaTime > COMPUTE_INTERVAL || last.velocity === undefined)) {
+    if (input.eventType != INPUT_CANCEL && (deltaTime > computeInterval || last.velocity === undefined)) {
         var deltaX = input.deltaX - last.deltaX;
         var deltaY = input.deltaY - last.deltaY;
 

--- a/tests/unit/test_hammer.js
+++ b/tests/unit/test_hammer.js
@@ -157,3 +157,13 @@ test('Remove non-existent recognizer.', function() {
 
     equal(1, hammer.recognizers.length);
 });
+
+test('Can set the computeInterval as an option', function() {
+    hammer = new Hammer(el);
+
+    equal(25, hammer.options.computeInterval);
+
+    hammer = new Hammer(el, {computeInterval: 100});
+
+    equal(100, hammer.options.computeInterval);
+});


### PR DESCRIPTION
I have been experiencing issues in detecting swipe events on the following browsers:
* Safari on Iphone 4
* Stock Android browser on Samsung tablets

Basically, the `swipeleft` and `swiperight` events were not being emitted upon swipe.

After some debugging, I noticed that the reason was that the last event of the swipe, the one with `inputType == INPUT_END` was not being triggered fast enough after the last `INPUT_MOVE`, so the last call to `computeIntervalInputData` was considering these two as two separate events, but they actually had the same coordinates, leading to a mistake in direction detection and, ultimately, in the impossibility to properly emit the swipe event with the appropriate direction.

I also found out that increasing the value of `COMPUTE_INTERVAL` from 25 to 50 solved my case, but since `COMPUTE_INTERVAL` is not accessible from the outside I decided to make it configurable as a manager property: the default value is preserved, but it can be overridden in initialization if needed. 