### PR TITLE
chore(test/demo): enhance the multi instance manual test

### DIFF
--- a/tests/manual/multiple.html
+++ b/tests/manual/multiple.html
@@ -9,14 +9,12 @@
 
         #right,
         #left {
-            display: block;
+            height: 580px;
             width: 50%;
-            height: 500px;
+            font-size: .8em;
+            float: left;
             overflow: hidden;
         }
-
-        #left { float: left; }
-        #right { float: right; }
 
     </style>
 </head>
@@ -44,6 +42,8 @@
                         value = "Array("+ value.length +"):"+ value;
                     } else if(value instanceof HTMLElement) {
                         value = value +" ("+ value.outerHTML.substring(0, 50) +"...)";
+                    } else if(key === 'center') {
+                        value = '{ x: '+value.x+', y: '+value.y+' }';
                     }
                     output.push(key +": "+ value);
                 }


### PR DESCRIPTION
- make each pane show all info vertically for screen sizes >= 320x480
- show center coordinates ( instead of [object Object] )
- example usage: when doing a swipe(w/ tap and swipe only registered),
  showing the center coordinates(e.g., x:24,y:23) makes it obvious that
  the distance you swiped, given by the distance k/v pair, is accurate