### PR TITLE
Reinsert missing license (MIT)

### DIFF
--- a/hammer.js
+++ b/hammer.js
@@ -2,7 +2,7 @@
  * http://hammerjs.github.io/
  *
  * Copyright (c) 2015 Jorik Tangelder;
- * Licensed under the  license */
+ * Licensed under the MIT license */
 (function(window, document, exportName, undefined) {
   'use strict';
 


### PR DESCRIPTION
This PR restores the MIT license entry in /hammer.js