### PR TITLE
Make sure that the required parameters are present

### DIFF
--- a/src/manager.js
+++ b/src/manager.js
@@ -193,8 +193,12 @@ Manager.prototype = {
      * @returns {EventEmitter} this
      */
     on: function(events, handler) {
-        if(events === undefined) return;
-        if(handler === undefined) return;
+        if (events === undefined) {
+            return;
+        }
+        if (handler === undefined) {
+            return;
+        }
 
         var handlers = this.handlers;
         each(splitStr(events), function(event) {
@@ -211,7 +215,9 @@ Manager.prototype = {
      * @returns {EventEmitter} this
      */
     off: function(events, handler) {
-        if(events === undefined) return;
+        if (events === undefined) {
+            return;
+        }
 
         var handlers = this.handlers;
         each(splitStr(events), function(event) {

--- a/src/manager.js
+++ b/src/manager.js
@@ -193,6 +193,9 @@ Manager.prototype = {
      * @returns {EventEmitter} this
      */
     on: function(events, handler) {
+        if(events === undefined) return;
+        if(handler === undefined) return;
+
         var handlers = this.handlers;
         each(splitStr(events), function(event) {
             handlers[event] = handlers[event] || [];
@@ -208,6 +211,8 @@ Manager.prototype = {
      * @returns {EventEmitter} this
      */
     off: function(events, handler) {
+        if(events === undefined) return;
+
         var handlers = this.handlers;
         each(splitStr(events), function(event) {
             if (!handler) {


### PR DESCRIPTION
Make sure that the required parameters are present for "on"  and "off" method like it is specified in https://hammerjs.github.io/jsdoc/Manager.html#on and https://hammerjs.github.io/jsdoc/Manager.html#off

Currently, if you call Hammer.on('tap', undefined) it will try to fire the "undefined" event handler.