### PR TITLE
Fix to make event.target the actual target where pan started

### DIFF
--- a/src/recognizers/pan.js
+++ b/src/recognizers/pan.js
@@ -9,6 +9,8 @@ function PanRecognizer() {
 
     this.pX = null;
     this.pY = null;
+    this.firstSrcEvent = null;
+    this.firstTarget = null;
 }
 
 inherit(PanRecognizer, AttrRecognizer, {
@@ -60,6 +62,12 @@ inherit(PanRecognizer, AttrRecognizer, {
     },
 
     attrTest: function(input) {
+        // Save the initial target element. If the threshold is greater than
+        // the element itself, the pointer will land on a different element.
+        if (input.isFirst) {
+            this.firstSrcEvent = input.srcEvent;
+            this.firstTarget = input.target;
+        }
         return AttrRecognizer.prototype.attrTest.call(this, input) &&
             (this.state & STATE_BEGAN || (!(this.state & STATE_BEGAN) && this.directionTest(input)));
     },
@@ -68,6 +76,9 @@ inherit(PanRecognizer, AttrRecognizer, {
 
         this.pX = input.deltaX;
         this.pY = input.deltaY;
+
+        input.srcEvent = this.firstSrcEvent;
+        input.target = this.firstTarget;
 
         var direction = directionStr(input.direction);
 

--- a/tests/manual/panstart.html
+++ b/tests/manual/panstart.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1, maximum-scale=1">
+    <title>Hammer.js</title>
+    <style>
+        body, .noselect {
+            -webkit-touch-callout: none;
+            -webkit-user-select: none;
+            -ms-user-select: none;
+            user-select: none;
+        }
+        #out {
+            white-space:pre;
+            border: 1px solid #666;
+            margin-top: 20px;
+            background: #ddd;
+            height: 110px;
+            text-align: center;
+            font: 20px/25px Helvetica, Arial, sans-serif;
+            padding:30px;
+        }
+        #wrapper {background:#ccf; height:100px; position:relative;}
+        .dragger {width:10px; height:10px; position:absolute; top:30px; left: 30px; background:#c00;}
+        .dragger.big {width:30px; height:30px;}
+    </style>
+</head>
+<body>
+
+    <div id="stage">
+        <div id="wrapper">
+            <div id="dragger_1" class="dragger"></div>
+            <div id="dragger_2" class="dragger" style="left:60px;"></div>
+            <div id="dragger_3" class="dragger big" style="left:90px;"></div>
+        </div>
+    </div>
+
+    <div id="out"></div>
+
+    <script src="../../hammer.js"></script>
+    <script>
+        var stage = document.getElementById('stage');
+        var out = document.getElementById('out');
+
+        var mc = new Hammer(stage);
+        mc.get('pan').set({ direction: Hammer.DIRECTION_ALL, threshold:12 });
+        mc.on('panstart', function(e) {
+            out.textContent = e.type +'\n Event.Target ID="' + e.target.id + '"\n Event.srcEvent.target ID="' + e.srcEvent.target.id + '"\n(Expected: ID="' + getActualDragStartElement(e).id + '")';
+        });
+        mc.on('panend', function() {
+            out.textContent = '';
+        });
+
+        function getActualDragStartElement(e) {
+            var pointer = e.pointers[0] || e.srcEvent;
+            return document.elementFromPoint(pointer.clientX - e.deltaX, pointer.clientY - e.deltaY);
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Hi @arschmitz @runspired! Yet another GSOC hopeful here ahaha. Figured I should try to make a small contribution before submitting a proposal. ;) Sorry for not expressing my interest sooner - just finished final exams for the quarter last week whoot!

Anyways, this is a Fix for Issue #815. I have tested the changes on Chrome (49.0.2623.87), Firefox (44.0.2), and Safari (9.0.3) using the demo kindly provided by @LeJared. Changes are local to only `src/recognizers/pan.js` and `tests/manual/panstart.html`. 

Any feedback is appreciated! Please let me know if I should change or clarify anything. Thanks so much for your time. :)

**Before**, `event.target` is set to the element where the mouse pointer is at, after it has moved at least `PanRecognizer.options.threshold` pixels away from the `mousedown` position. This would normally not be a problem if the target element's size is greater than `threshold` pixels, as the mouse pointer would still be within the target element at the end of the pan gesture, thus `event.target` would still be set to the expected element. 

However, if the element we originally panned over is smaller than `threshold` pixels, by the time the pan gesture has been recognized, the mouse pointer would be over a different element, not the original element of `panstart` (not what we want).

**Now**, the `event.target` of the pan gesture is set to where the user originally clicked (on `panstart`), as expected. This is done by saving the original target element, and updating the input before emitting it to the listeners.