### PR TITLE
Refactor: bump to grunt-contrib-uglify v0.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "grunt-contrib-connect": "0.7.x",
     "grunt-contrib-jshint": "0.10.x",
     "grunt-contrib-qunit": "^0.5.1",
-    "grunt-contrib-uglify": "0.4.x",
+    "grunt-contrib-uglify": "0.7.x",
     "grunt-contrib-watch": "0.6.x",
     "grunt-jscs": "^0.8.0",
     "grunt-string-replace": "^0.2.7",


### PR DESCRIPTION
Forgot to mention this earlier, but I ran into build issues a couple days ago associated with sourceMappingURL during the minification process. Maybe it's just my machine? :bowtie: But I checked the release history for grunt-contrib-uglify and upgrading to v0.7 solves this for me.