### PR TITLE
QuickFix(#881): Fix Missing Recognizer.prototype.constructor

### DIFF
--- a/src/recognizer.js
+++ b/src/recognizer.js
@@ -276,6 +276,10 @@ Recognizer.prototype = {
     reset: function() { }
 };
 
+Object.defineProperty(Recognizer.prototype, 'constructor', {
+    value: Recognizer
+});
+
 /**
  * get a usable string, used as event postfix
  * @param {Const} state


### PR DESCRIPTION
Fix the error "Recognizer.prototype.constructor is not defined" by
defining a property constructor = Recognizer on Recognizer.prototype