### PR TITLE
fix(SwipeRecognizer): related to Issue #815

### DIFF
--- a/src/recognizers/pan.js
+++ b/src/recognizers/pan.js
@@ -9,6 +9,8 @@ function PanRecognizer() {
 
     this.pX = null;
     this.pY = null;
+    this.firstSrcEvent = null;
+    this.firstTarget = null;
 }
 
 inherit(PanRecognizer, AttrRecognizer, {
@@ -60,6 +62,12 @@ inherit(PanRecognizer, AttrRecognizer, {
     },
 
     attrTest: function(input) {
+        // Save the initial target element. If the threshold is greater than
+        // the element itself, the pointer will land on a different element.
+        if (input.isFirst) {
+            this.firstSrcEvent = input.srcEvent;
+            this.firstTarget = input.target;
+        }
         return AttrRecognizer.prototype.attrTest.call(this, input) &&
             (this.state & STATE_BEGAN || (!(this.state & STATE_BEGAN) && this.directionTest(input)));
     },
@@ -68,6 +76,9 @@ inherit(PanRecognizer, AttrRecognizer, {
 
         this.pX = input.deltaX;
         this.pY = input.deltaY;
+
+        input.srcEvent = this.firstSrcEvent;
+        input.target = this.firstTarget;
 
         var direction = directionStr(input.direction);
 

--- a/src/recognizers/swipe.js
+++ b/src/recognizers/swipe.js
@@ -6,6 +6,9 @@
  */
 function SwipeRecognizer() {
     AttrRecognizer.apply(this, arguments);
+
+    this.firstSrcEvent = null;
+    this.firstTarget = null;
 }
 
 inherit(SwipeRecognizer, AttrRecognizer, {
@@ -36,6 +39,12 @@ inherit(SwipeRecognizer, AttrRecognizer, {
         } else if (direction & DIRECTION_VERTICAL) {
             velocity = input.overallVelocityY;
         }
+        // Save the initial target element. If the threshold is greater than
+        // the element itself, the pointer will land on a different element.
+        if (input.isFirst) {
+            this.firstSrcEvent = input.srcEvent;
+            this.firstTarget = input.target;
+        }
 
         return this._super.attrTest.call(this, input) &&
             direction & input.offsetDirection &&
@@ -49,6 +58,8 @@ inherit(SwipeRecognizer, AttrRecognizer, {
         if (direction) {
             this.manager.emit(this.options.event + direction, input);
         }
+        input.srcEvent = this.firstSrcEvent;
+        input.target = this.firstTarget;
 
         this.manager.emit(this.options.event, input);
     }

--- a/tests/manual/panstart.html
+++ b/tests/manual/panstart.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1, maximum-scale=1">
+    <title>Hammer.js</title>
+    <style>
+        body, .noselect {
+            -webkit-touch-callout: none;
+            -webkit-user-select: none;
+            -ms-user-select: none;
+            user-select: none;
+        }
+        #out {
+            white-space:pre;
+            border: 1px solid #666;
+            margin-top: 20px;
+            background: #ddd;
+            height: 110px;
+            text-align: center;
+            font: 20px/25px Helvetica, Arial, sans-serif;
+            padding:30px;
+        }
+        #wrapper {background:#ccf; height:100px; position:relative;}
+        .dragger {width:10px; height:10px; position:absolute; top:30px; left: 30px; background:#c00;}
+        .dragger.big {width:30px; height:30px;}
+    </style>
+</head>
+<body>
+
+    <div id="stage">
+        <div id="wrapper">
+            <div id="dragger_1" class="dragger"></div>
+            <div id="dragger_2" class="dragger" style="left:60px;"></div>
+            <div id="dragger_3" class="dragger big" style="left:90px;"></div>
+        </div>
+    </div>
+
+    <div id="out"></div>
+
+    <script src="../../hammer.js"></script>
+    <script>
+        var stage = document.getElementById('stage');
+        var out = document.getElementById('out');
+
+        var mc = new Hammer(stage);
+        mc.get('pan').set({ direction: Hammer.DIRECTION_ALL, threshold:12 });
+        mc.on('panstart', function(e) {
+            out.textContent = e.type +'\n Event.Target ID="' + e.target.id + '"\n Event.srcEvent.target ID="' + e.srcEvent.target.id + '"\n(Expected: ID="' + getActualDragStartElement(e).id + '")';
+        });
+        mc.on('panend', function() {
+            out.textContent = '';
+        });
+
+        function getActualDragStartElement(e) {
+            var pointer = e.pointers[0] || e.srcEvent;
+            return document.elementFromPoint(pointer.clientX - e.deltaX, pointer.clientY - e.deltaY);
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Hey @thejae, yeah I think you're right. I believe your Issue #945 is related to #815 and #942 since Pan and Swipe gestures are somewhat similar. For now though, you can get around it with this. 

Cache the the first `srcEvent` in the `SwipeRecognizer` and retrieve it during emit. Also, I'm not sure about you mean about `ev.srcEvent.toElement` and `ev.srcEvent.srcElement` since I can't find those properties.