### PR TITLE
Fix: Panstart event not recognized after .stop() #811

### DIFF
--- a/src/manager.js
+++ b/src/manager.js
@@ -70,6 +70,7 @@ Manager.prototype = {
     recognize: function(inputData) {
         var session = this.session;
         if (session.stopped) {
+            session.curRecognizer.state = STATE_ENDED;
             return;
         }
 


### PR DESCRIPTION
Here is my attempt on fixing the `.stop()` issue with the `panstart` event. By changing the state for the current recognizer in the session to `STATE_ENDED` ends the flow and the pan event will start from the beginning next time.
