### PR TITLE
chore(gruntfile): fix license string in banner

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -11,7 +11,7 @@ module.exports = (grunt) ->
  * <%= pkg.homepage %>\n
  *\n
  * Copyright (c) <%= grunt.template.today("yyyy") %> <%= pkg.author.name %>;\n
- * Licensed under the <%= _.pluck(pkg.licenses, "type").join(", ") %> license */'
+ * Licensed under the <%= pkg.license %> license */'
           linebreak: true
         files:
           src: ['./hammer.js','./hammer.min.js']


### PR DESCRIPTION
Template tag was incorrect and hence rendering empty: "Licensed under the  license", presumably
since c2578cd.

Closes #949