### PR TITLE
Update simulator test to point to the correct hammer file

### DIFF
--- a/tests/manual/simulator.html
+++ b/tests/manual/simulator.html
@@ -19,7 +19,7 @@
 </div>
 
 <script src="../../node_modules/hammer-simulator/index.js"></script>
-<script src="../build.js"></script>
+<script src="../../hammer.js"></script>
 <script>
 
     var program = [


### PR DESCRIPTION
Currently /tests/manual/simulator.html points to a non-existent `../build.js` file. Because of this the following error is received

> ReferenceError: Hammer is not defined
> var mc = new Hammer(el);
> -------^

Update the path from `../build.js` to the correct `../../hammer.js` to get rid of this error and make the manual test function again. 