### PR TITLE
feat(TouchAction) touch-action style is restored in Hammer.destroy

### DIFF
--- a/src/expose.js
+++ b/src/expose.js
@@ -21,6 +21,9 @@ assign(Hammer, {
     DIRECTION_VERTICAL: DIRECTION_VERTICAL,
     DIRECTION_ALL: DIRECTION_ALL,
 
+    PREFIXED_TOUCH_ACTION: PREFIXED_TOUCH_ACTION,
+    NATIVE_TOUCH_ACTION: NATIVE_TOUCH_ACTION,
+
     Manager: Manager,
     Input: Input,
     TouchAction: TouchAction,

--- a/src/manager.js
+++ b/src/manager.js
@@ -269,6 +269,7 @@ Manager.prototype = {
 
         this.handlers = {};
         this.session = {};
+        this.touchAction.destroy();
         this.input.destroy();
         this.element = null;
     }

--- a/src/touchaction.js
+++ b/src/touchaction.js
@@ -8,7 +8,7 @@ var TOUCH_ACTION_MANIPULATION = 'manipulation'; // not implemented
 var TOUCH_ACTION_NONE = 'none';
 var TOUCH_ACTION_PAN_X = 'pan-x';
 var TOUCH_ACTION_PAN_Y = 'pan-y';
-var TOUCH_ACTION_MAP = getTouchActionProps();
+var TOUCH_ACTION_MAP = NATIVE_TOUCH_ACTION ? getTouchActionProps() : false;
 
 /**
  * Touch Action
@@ -19,6 +19,7 @@ var TOUCH_ACTION_MAP = getTouchActionProps();
  */
 function TouchAction(manager, value) {
     this.manager = manager;
+    this.orginalTouchActionStyle = this.canApplyStyle() ? this.manager.element.style[Hammer.PREFIXED_TOUCH_ACTION] : '';
     this.set(value);
 }
 
@@ -33,8 +34,8 @@ TouchAction.prototype = {
             value = this.compute();
         }
 
-        if (NATIVE_TOUCH_ACTION && this.manager.element.style && TOUCH_ACTION_MAP[value]) {
-            this.manager.element.style[PREFIXED_TOUCH_ACTION] = value;
+        if (this.canApplyStyle() && TOUCH_ACTION_MAP[value]) {
+            this.manager.element.style[Hammer.PREFIXED_TOUCH_ACTION] = value;
         }
         this.actions = value.toLowerCase().trim();
     },
@@ -110,6 +111,24 @@ TouchAction.prototype = {
     preventSrc: function(srcEvent) {
         this.manager.session.prevented = true;
         srcEvent.preventDefault();
+    },
+
+    /**
+     * Used to check if touch action property is applicable to element
+     * @memberof TouchAction
+     * @returns {Boolean} applicable
+     */
+    canApplyStyle: function() {
+        return !!(Hammer.NATIVE_TOUCH_ACTION && this.manager.element.style);
+    },
+
+    /**
+     * restore touch-action style value
+     */
+    destroy: function() {
+        if (this.canApplyStyle()) {
+            this.manager.element.style[Hammer.PREFIXED_TOUCH_ACTION] = this.orginalTouchActionStyle;
+        }
     }
 };
 
@@ -149,9 +168,6 @@ function cleanTouchActions(actions) {
 }
 
 function getTouchActionProps() {
-    if (!NATIVE_TOUCH_ACTION) {
-        return false;
-    }
     var touchMap = {};
     var cssSupports = window.CSS && window.CSS.supports;
     ['auto', 'manipulation', 'pan-y', 'pan-x', 'pan-x pan-y', 'none'].forEach(function(val) {

--- a/tests/unit/index.html
+++ b/tests/unit/index.html
@@ -33,7 +33,7 @@
 <script src="test_gestures.js"></script>
 <script src="test_multiple_taps.js"></script>
 <script src="test_require_failure.js"></script>
-
+<script src="test_touchaction.js"></script>
 <script src="test_jquery_plugin.js"></script>
 <script src="gestures/test_pan.js"></script>
 <script src="gestures/test_pinch.js"></script>

--- a/tests/unit/test_hammer.js
+++ b/tests/unit/test_hammer.js
@@ -185,3 +185,23 @@ test('check whether Hammer.defaults.cssProps is restored', function() {
         }
     });
 });
+
+test('check whether touch-action style is removed', function() {
+    var originalTouchActionStyle = 'manipulation';
+    // for not support browsers like phantomjs,...
+    if (!Hammer.NATIVE_TOUCH_ACTION) {
+        Hammer.PREFIXED_TOUCH_ACTION = 'touchAction';
+    }
+    el.style[Hammer.PREFIXED_TOUCH_ACTION] = originalTouchActionStyle;
+
+    Hammer.defaults.touchAction = 'pan-y';
+    hammer = Hammer(el);
+
+    if (Hammer.NATIVE_TOUCH_ACTION) {
+        notEqual(originalTouchActionStyle, el.style[Hammer.PREFIXED_TOUCH_ACTION]);
+    }
+
+    hammer.destroy();
+    hammer = null;
+    equal(originalTouchActionStyle, el.style[Hammer.PREFIXED_TOUCH_ACTION], "returns original touch-action style.");
+});

--- a/tests/unit/test_touchaction.js
+++ b/tests/unit/test_touchaction.js
@@ -1,0 +1,60 @@
+var el, manager, touchAction,
+	ORG_PREFIXED_TOUCH_ACTION = Hammer.PREFIXED_TOUCH_ACTION
+	ORG_NATIVE_TOUCH_ACTION = Hammer.NATIVE_TOUCH_ACTION;
+
+module('touchAction Tests', {
+    setup: function() {
+        el = utils.createHitArea();
+        manager = {
+        	options: Hammer.assign({}, Hammer.defaults),
+        	handlers: {},
+        	session: {},
+        	recognizers: [],
+        	element : el
+        };
+    },
+
+    teardown: function() {
+        if (touchAction) {
+        	touchAction.destroy();
+        	touchAction = null;
+        }
+        Hammer.PREFIXED_TOUCH_ACTION = ORG_PREFIXED_TOUCH_ACTION;
+        Hammer.NATIVE_TOUCH_ACTION = ORG_NATIVE_TOUCH_ACTION;
+        manager = null;
+    }
+});
+
+test('check whether touch-action style is removed', function() {
+	var originalTouchActionStyle = 'manipulation';
+
+    // for not support browsers like phantomjs,...
+	if (!Hammer.NATIVE_TOUCH_ACTION) {
+		Hammer.PREFIXED_TOUCH_ACTION = 'touchAction';
+	}
+	el.style[Hammer.PREFIXED_TOUCH_ACTION] = originalTouchActionStyle;
+    touchAction = new Hammer.TouchAction(manager, "compute");
+
+    if (Hammer.NATIVE_TOUCH_ACTION) {
+    	notEqual(originalTouchActionStyle, el.style[Hammer.PREFIXED_TOUCH_ACTION]);
+    }
+
+    touchAction.destroy();
+    touchAction = null;
+    equal(originalTouchActionStyle, el.style[Hammer.PREFIXED_TOUCH_ACTION], "returns original touch-action style.");
+});
+
+
+test('check whether canApplyStyle method returns a correct value', function() {
+	touchAction = new Hammer.TouchAction(manager, "compute");
+	Hammer.PREFIXED_TOUCH_ACTION = 'touchAction';
+
+    Hammer.NATIVE_TOUCH_ACTION = false;
+    equal(touchAction.canApplyStyle(), false, "if touch-action is not supported, canApplyStyle method should return false");
+
+	Hammer.NATIVE_TOUCH_ACTION = true;
+    equal(touchAction.canApplyStyle(), true, "if touch-action is supported, canApplyStyle method should return true");
+
+    manager.element = {};
+	equal(touchAction.canApplyStyle(), false, "if element does not include style property, canApplyStyle method should return false");
+});


### PR DESCRIPTION
I resend this pr.
- prev pr : #900 
- reference issue : #853 

touch-action style is not removed on destroy.
so, I add originalTouchActionStyle property for caching and some methods.
- add destroy, canApplyStyle methods in TouchAction.
- add PREFIXED_TOUCH_ACTION, NATIVE_TOUCH_ACTION in Hammer for testing.
- add 'test_touchaction.js' testcase