### PR TITLE
fix: wrap constructor in a factory function so callable from node.js

### DIFF
--- a/src/hammer.prefix.js
+++ b/src/hammer.prefix.js
@@ -1,2 +1,33 @@
-(function(window, document, exportName, undefined) {
+( function( global, expose ) {
+
   'use strict';
+
+  // test for existence of module and module.exports which will clue us in
+  // to a CommonJS environment
+  if ( typeof module === 'object' && typeof module.exports === 'object' ) {
+
+    // For CommonJS and CommonJS-like environments where a proper `window`
+    // is present, execute the expose function to initialize Hammer and
+    // expose to environment via AMD, CommonJS, etc.
+    // For environments that do not have a `window` with a `document`
+    // (such as Node.js), export a factory as module.exports.
+    // This accentuates the need for the creation of a real `window`.
+    // e.g. var hammertime = require("hammer")(window);
+    if (global.document) {
+      expose( global, global.document, 'Hammer' );
+    } else {
+      module.exports = function( w ) {
+        if ( !w.document ) {
+          throw new Error( 'Hammer requires a window with a document' );
+        }
+        return expose( w, w.document, 'Hammer' );
+      };
+    }
+  } else {
+    expose( global, global.document, 'Hammer' );
+  }
+
+// Pass this if window is not defined yet
+}( typeof window !== 'undefined' ? window : this, function( window, document, exportName ) {
+
+'use strict';

--- a/src/hammer.suffix.js
+++ b/src/hammer.suffix.js
@@ -1,1 +1,1 @@
-})(window, document, 'Hammer');
+} ) );


### PR DESCRIPTION
Fixes #930.  This wraps the constructor in a factory function that is callable from both browser and backend server environments which is necessary for server side rendering (via React, etc.).  The implementation uses a jQuery style approach by returning a factory function when `window` or `window.document` are not available that can be used for later initialization.
