### PR TITLE
fix(MouseInput): check the pressed button with ev.button property instead of ev.which

### DIFF
--- a/src/input/mouse.js
+++ b/src/input/mouse.js
@@ -34,7 +34,7 @@ inherit(MouseInput, Input, {
             this.pressed = true;
         }
 
-        if (eventType & INPUT_MOVE && ev.which !== 1) {
+        if (eventType & INPUT_MOVE && ev.button !== 0) {
             eventType = INPUT_END;
         }
 


### PR DESCRIPTION
Fixes #976. This replaces the non-standard [MouseEvent.which](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/which) property check with the recommended [MouseEvent.button](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button).

Tested on OSX 10.11.4: Chrome 50, WebDriver (ChromeDriver) 2.19, Safari 9.1, Firefox 46; Windows 7: IE11, Chrome 50.