### PR TITLE
Add passive event listeners

### DIFF
--- a/hammer.js
+++ b/hammer.js
@@ -219,7 +219,7 @@ function ifUndefined(val1, val2) {
  */
 function addEventListeners(target, types, handler) {
     each(splitStr(types), function(type) {
-        target.addEventListener(type, handler, false);
+        target.addEventListener(type, handler, { passive: true });
     });
 }
 
@@ -231,7 +231,7 @@ function addEventListeners(target, types, handler) {
  */
 function removeEventListeners(target, types, handler) {
     each(splitStr(types), function(type) {
-        target.removeEventListener(type, handler, false);
+        target.removeEventListener(type, handler, { passive: true });
     });
 }
 


### PR DESCRIPTION
For scrolling and touch event listeners that do not call `e.preventDefault()` it is a big performance boost to set the option passive to true to tell the browser that your event is not blocking and should not disrupt the main thread.

https://www.chromestatus.com/features/5745543795965952
https://github.com/WICG/EventListenerOptions/blob/gh-pages/explainer.md