### PR TITLE
[NPM] Add: files setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,9 @@
   "bugs": {
     "url": "https://github.com/hammerjs/hammer.js/issues"
   },
+  "files": [
+    "hammer.js"
+  ],
   "dependencies": {},
   "devDependencies": {
     "changelogplease": "^1.2.0",


### PR DESCRIPTION
When I install this lib via 'npm install', node_modules/hammerjs has full this repo's files.
I add files setting into  package.json, then,  node_modules/hammerjs  has only hammer.js, Readme and changelog files
