### PR TITLE
chore(rollup version): bumps up rollup version

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "lodash-compat": "^3.10.2",
     "node-qunit-phantomjs": "^1.4.0",
     "qunitjs": "^2.0.0",
-    "rollup": "^0.26.3",
+    "rollup": "^0.36.0",
     "rollup-plugin-babel": "^2.4.0",
     "run-when-changed": "^1.2.0",
     "serve": "^1.4.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,8 +2,8 @@ import babel from 'rollup-plugin-babel';
 
 export default {
   entry: 'src/main.js',
-  format: 'es6',
-  plugins: [ babel({exclude: 'node_modules/**'}) ],
+  format: 'es',
+  plugins: [ babel({ exclude: 'node_modules/**' }) ],
   dest: 'hammer.js',
   intro: " (function(window, document, exportName, undefined) { \n'use strict';",
   outro: "})(window, document, 'Hammer');"


### PR DESCRIPTION
### This PR 

- bumps up rollup.js to newest version.
- handles a minor deprecation in the `format` option in rollup config.