### PR TITLE
Clear references to DOM elements

### DIFF
--- a/src/manager.js
+++ b/src/manager.js
@@ -295,7 +295,9 @@ export default class Manager {
     this.handlers = {};
     this.session = {};
     this.input.destroy();
+    this.input = null;
     this.element = null;
+    this.options.inputTarget = null;
   }
 }
 


### PR DESCRIPTION
Keeping these references results, under certain conditions, to a
detached DOM tree