### PR TITLE
fix(input): fix pointerEvent bug

### DIFF
--- a/src/input/mouse.js
+++ b/src/input/mouse.js
@@ -29,6 +29,7 @@ export default class MouseInput extends Input {
     this.evWin = MOUSE_WINDOW_EVENTS;
 
     this.pressed = false; // mousedown state
+    this.init();
   }
 
   /**

--- a/src/input/pointerevent.js
+++ b/src/input/pointerevent.js
@@ -48,6 +48,7 @@ export default class PointerEventInput extends Input {
     this.evEl = POINTER_ELEMENT_EVENTS;
     this.evWin = POINTER_WINDOW_EVENTS;
 
+    this.init();
     this.store = (this.manager.session.pointerEvents = []);
   }
 

--- a/src/input/singletouch.js
+++ b/src/input/singletouch.js
@@ -32,7 +32,7 @@ export default class SingleTouchInput extends Input {
     this.evWin = SINGLE_TOUCH_WINDOW_EVENTS;
     this.started = false;
 
-    Input.apply(this, arguments);
+    this.init();
   }
 
   handler(ev) {

--- a/src/input/touch.js
+++ b/src/input/touch.js
@@ -28,12 +28,12 @@ const TOUCH_TARGET_EVENTS = 'touchstart touchmove touchend touchcancel';
 export default class TouchInput extends Input {
 
   constructor() {
-    TouchInput.prototype.evTarget = TOUCH_TARGET_EVENTS;
-    TouchInput.prototype.targetIds = {};
     super(...arguments);
 
     this.evTarget = TOUCH_TARGET_EVENTS;
     this.targetIds = {};
+
+    this.init();
   }
 
   handler(ev) {

--- a/src/input/touchmouse.js
+++ b/src/input/touchmouse.js
@@ -27,7 +27,7 @@ const DEDUP_DISTANCE = 25;
 export default class TouchMouseInput extends Input {
   constructor() {
     super(...arguments);
-
+    this.init();
     let handler = bindFn(this.handler, this);
     this.touch = new TouchInput(this.manager, handler);
     this.mouse = new MouseInput(this.manager, handler);

--- a/src/inputjs/input-constructor.js
+++ b/src/inputjs/input-constructor.js
@@ -26,9 +26,6 @@ export default class Input {
         self.handler(ev);
       }
     };
-
-    this.init();
-
   }
   /**
    * @private


### PR DESCRIPTION
the Master branch of hammerjs is broken.

Hammerjs attach events in `init` method.
but, PointerInput, MouseInput,... didn't ready yet.
so, init method didn't attach pointer events.  

ref #1084