### PR TITLE
Prevent onPanStart from being fired from pointercancel event

### DIFF
--- a/src/recognizers/attribute.js
+++ b/src/recognizers/attribute.js
@@ -54,7 +54,7 @@ export default class AttrRecognizer extends Recognizer {
     } else if (isRecognized || isValid) {
       if (eventType & INPUT_END) {
         return state | STATE_ENDED;
-      } else if (!(state & STATE_BEGAN)) {
+      } else if (!input.isFinal && !(state & STATE_BEGAN)) {
         return STATE_BEGAN;
       }
       return state | STATE_CHANGED;


### PR DESCRIPTION
This improves behavior on Android associated with #1050. This is reproducible when panning content that also scrolls vertically - if you scroll the content hammer is firing a spurious `onPanStart` event, and the state machine gets messed up for subsequent pan events until you scroll horizontally again.

I've created a simple test application that demonstrates the problem: https://github.com/MattKunze/swipe-handler

You can reproduce the behavior in Chrome by simulating a device. The following video shows the behavior - the first swipe works because the scroll position isn't change, after scrolling vertically you see the incorrect `onPanStart` event, and panning doesn't work until it resets after the the stream of touch events ends, then you can repeat the process:

![video](http://g.recordit.co/KbUqIyiTgU.gif)

Note that I'm still needing to reject events where `ev.srcEvent.type === 'pointercancel'`, but this is needed to fix the behavior where a lot of pans aren't recognized on Android in the first place