### PR TITLE
Do not use a timer for an explicit timeout of 0

### DIFF
--- a/src/utils/set-timeout-context.js
+++ b/src/utils/set-timeout-context.js
@@ -9,5 +9,10 @@ import bindFn from './bind-fn';
  * @returns {number}
  */
 export default function setTimeoutContext(fn, timeout, context) {
-  return setTimeout(bindFn(fn, context), timeout);
+  if(timeout === 0) {
+    fn.call( context );
+    return null;
+  } else {
+    return setTimeout(bindFn(fn, context), timeout); 
+  }
 }


### PR DESCRIPTION
The `Press` gesture recognizer in HammerJS has problems consistently firing a `pressup` event following a `press` event in the context of small `time` values. This is well-known. See e.g. #1011, #836, #751.

We've found that given a pair of `Press` and `Pan` gestures configured as below, the `pressup` event will fairly consistently break ( especially when using touch input ).
This particular scenario is used for detecting a `Press` for instant setting of a position and `Pan` gradually controlling a set position ( we specifically use this for creating a "dual-ended between" variant of the `input type="range"` ):

```js
{
  recognizers : [
    [ Hammer.Pan, {
      direction : Hammer.DIRECTION_HORIZONTAL,
      threshold : 0
    }],
    [ Hammer.Press, {
      threshold : 1,
      time      : 0
    }]
   ]
}```

The root cause is with a granularity problem with browser timeouts as used in the `setTimeoutContext`, which causes part of the gesture logic to fire too late (or not at all). This issue and probably others like it, such as #1011, #836 or #751 can be fixed by not using a timeout at all if the gesture's `time` property is 0.