### PR TITLE
Adding inputHandler method to exports to call it from other JS file

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -28,6 +28,7 @@ import {
 
 import Manager from './manager';
 import Input from './inputjs/input-constructor';
+import inputHandler from './inputjs/input-handler';
 import TouchAction from './touchactionjs/touchaction-constructor';
 import TouchInput from './input/touch';
 import MouseInput from './input/mouse';
@@ -94,6 +95,7 @@ assign(Hammer, {
   PointerEventInput,
   TouchMouseInput,
   SingleTouchInput,
+  inputHandler,
 
   Recognizer,
   AttrRecognizer,


### PR DESCRIPTION
[Requirement] To use computation and recognizer part of hammer and registering for browser input events by our own instead of using Hammer Manager for registration.
[Change] Adding inputHandler method to module.exports to make it publicly available. This makes us to use computation part of hammer from outside hammer JS
