### PR TITLE
Fix jsdoc annotation of inArray method.

### DIFF
--- a/hammer.js
+++ b/hammer.js
@@ -213,7 +213,7 @@ function invokeArrayArg(arg, fn, context) {
  * @param {Array} src
  * @param {String} find
  * @param {String} [findByKey]
- * @return {Boolean|Number} false when not found, or the index
+ * @return {number} -1 when not found, or the index
  */
 function inArray(src, find, findByKey) {
   if (src.indexOf && !findByKey) {


### PR DESCRIPTION
This method always returns a number. and the rest of the library is treating the result of this method as number. Using {Boolean|Number} as return type confuses the closure compiler.

Related to cl/247235272