### PR TITLE
Add support for selectors

### DIFF
--- a/src/hammer.js
+++ b/src/hammer.js
@@ -18,6 +18,7 @@ import  Manager  from './manager';
  */
 export default class Hammer {
   constructor(element, options) {
+    if(!element instanceof HTMLElement) element = document.querySelector(element);
     options = options || {};
     options.recognizers = ifUndefined(options.recognizers, Hammer.defaults.preset);
     return new Manager(element, options);


### PR DESCRIPTION
If element isn't HTMElement, try to use querySelector method.
Issue: #1220 