### PR TITLE
Fixed issue with window not being present on intialisation

### DIFF
--- a/hammer.js
+++ b/hammer.js
@@ -3,7 +3,7 @@
  *
  * Copyright (c)  Jorik Tangelder;
  * Licensed under the MIT license */
-(function(window, document, exportName, undefined) { 
+if( typeof window !== "undefined" && typeof document !== "undefined" )(function(window, document, exportName, undefined) { 
 'use strict';
 /**
  * @private


### PR DESCRIPTION
When using webpack and web workers hammerjs can receive an undefined window and document, this if statement blocks it from running unless those objects are present.