### PR TITLE
Don't round pointer position in simpleCloneInputData

### DIFF
--- a/src/inputjs/simple-clone-input-data.js
+++ b/src/inputjs/simple-clone-input-data.js
@@ -1,4 +1,4 @@
-import { now,round } from '../utils/utils-consts';
+import { now } from '../utils/utils-consts';
 import getCenter from './get-center';
 
 /**
@@ -14,8 +14,8 @@ export default function simpleCloneInputData(input) {
   let i = 0;
   while (i < input.pointers.length) {
     pointers[i] = {
-      clientX: round(input.pointers[i].clientX),
-      clientY: round(input.pointers[i].clientY)
+      clientX: input.pointers[i].clientX,
+      clientY: input.pointers[i].clientY
     };
     i++;
   }


### PR DESCRIPTION
This rounding was added back to 432d2fe14368ea3e1d237d880859118a2ea80bfc. There was no explanation why it was done that way.

However, this leads to a problem that a gesture can immediately trigger a change on the very first event, which can be undesirable.