### PR TITLE
docs: Fix simple typo, defalut -> default

### DIFF
--- a/hammer.js
+++ b/hammer.js
@@ -1726,7 +1726,7 @@ function getDirection(x, y) {
 function computeDeltaXY(session, input) {
   var center = input.center;
   // let { offsetDelta:offset = {}, prevDelta = {}, prevInput = {} } = session;
-  // jscs throwing error on defalut destructured values and without defaults tests fail
+  // jscs throwing error on default destructured values and without defaults tests fail
 
   var offset = session.offsetDelta || {};
   var prevDelta = session.prevDelta || {};

--- a/src/inputjs/compute-delta-xy.js
+++ b/src/inputjs/compute-delta-xy.js
@@ -3,7 +3,7 @@ import { INPUT_START, INPUT_END } from './input-consts';
 export default function computeDeltaXY(session, input) {
   let { center } = input;
   // let { offsetDelta:offset = {}, prevDelta = {}, prevInput = {} } = session;
-  // jscs throwing error on defalut destructured values and without defaults tests fail
+  // jscs throwing error on default destructured values and without defaults tests fail
   let offset = session.offsetDelta || {};
   let prevDelta = session.prevDelta || {};
   let prevInput = session.prevInput || {};


### PR DESCRIPTION
There is a small typo in hammer.js, src/inputjs/compute-delta-xy.js.

Should read `default` rather than `defalut`.

