### PR TITLE
Use https instead of git protocol for repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/hammerjs/hammer.js.git"
+    "url": "https://github.com/hammerjs/hammer.js"
   },
   "bugs": {
     "url": "https://github.com/hammerjs/hammer.js/issues"


### PR DESCRIPTION
As Github has disabled the Git protocol[0], accessing this repo using git:// is no longer possible and results in a time-out. This causes problems when Yarn attempts to download this package[1]. Changing this to https should solve this.

[0] https://github.blog/2021-09-01-improving-git-protocol-security-github/
[1] https://github.com/yarnpkg/yarn/issues/8833